### PR TITLE
Pity System

### DIFF
--- a/cogs/gameplay.py
+++ b/cogs/gameplay.py
@@ -36,17 +36,23 @@ class Gameplay(commands.Cog):
         
         actived_potions = {} if tier else func.get_potions(user.get("actived_potions", {}), func.settings.POTIONS_BASE)
         query = {}
+        guaranteed_tier = None
+
         if not tier:
+            # Normal roll - check if pity guarantees a tier
+            guaranteed_tier = func.check_pity_guarantee(user)
+
             query["$set"] = {"cooldown.roll": time.time() + (func.settings.COOLDOWN_BASE["roll"][1] * (1 - actived_potions.get("speed", 0)))}
 
         else:
+            # Purchased roll - don't affect pity
             tier = func.match_string(tier.lower(), func.settings.TIERS_BASE.keys())
             if not tier:
                 return await ctx.reply(f"Tier was not found. Please select a valid tier: `{', '.join(user.get('roll').keys())}`")
  
             if user.get("roll", {}).get(tier, 0) <= 0:
-                return await ctx.reply(f"You’ve used up all your `{tier}` rolls for now.")
-            
+                return await ctx.reply(f"You've used up all your `{tier}` rolls for now.")
+
             query["$inc"] = {f"roll.{tier}": -1}
 
         query = func.update_quest_progress(user, "ROLL", query=query)
@@ -57,7 +63,15 @@ class Gameplay(commands.Cog):
             view.add_item(discord.ui.Button(label='Beginner Guide', emoji='📗', url='https://docs.google.com/document/d/1VAD20wZQ56S_wDeMJlwIKn_jImIPuxh2lgy1fn17z0c/edit'))
             await ctx.reply(f"**Welcome to IUFI! Please have a look at the guide or use `qhelp` to begin.**", view=view)
 
-        cards = iufi.CardPool.roll(included=[tier] if tier else None, luck_rates=None if tier else actived_potions.get("luck", None))
+        # Roll cards with guaranteed tier if pity was triggered, otherwise use the purchased tier or normal roll
+        roll_tier = guaranteed_tier if guaranteed_tier else tier
+        cards = iufi.CardPool.roll(included=[roll_tier] if roll_tier else None, luck_rates=None if roll_tier else actived_potions.get("luck", None))
+
+        # Update pity based on rolled cards (only for normal rolls)
+        if not tier:
+            pity_query = func.update_pity_from_cards(user, cards)
+            await func.update_user(ctx.author.id, pity_query)
+
         image_bytes, image_format = await iufi.gen_cards_view(cards)
 
         view = RollView(ctx.author, cards)
@@ -178,6 +192,41 @@ class Gameplay(commands.Cog):
         """
         view = ShopView(ctx.author)
         view.message = await ctx.reply(embed=await view.build_embed(), view=view)
+
+    @commands.command(aliases=["mypity"], hidden=True)
+    async def pity(self, ctx: commands.Context, member: discord.Member = None):
+        """Shows pity progress for each tier. Admin only command.
+
+        **Examples:**
+        @prefix@pity
+        @prefix@pity @user
+        """
+        if ctx.author.id not in func.settings.ADMIN_IDS:
+            return await ctx.reply("This command is only available to administrators.", delete_after=5)
+
+        if not member:
+            member = ctx.author
+
+        user = await func.get_user(member.id)
+        user_pity = user.get("pity", {})
+
+        embed = discord.Embed(title=f"🎲 {member.display_name}'s Pity Progress", color=0x59b0c0)
+
+        pity_info = []
+        for tier, threshold in func.settings.PITY_SETTINGS.items():
+            current = user_pity.get(tier, 0)
+            progress_bar_length = 20
+            filled = int((current / threshold) * progress_bar_length)
+            bar = "█" * filled + "░" * (progress_bar_length - filled)
+            percentage = (current / threshold) * 100
+
+            pity_info.append(f"**{tier.capitalize()}**: {current}/{threshold} ({percentage:.1f}%)")
+            pity_info.append(f"{bar}\n")
+
+        embed.description = "\n".join(pity_info)
+        embed.set_footer(text="Normal rolls increment pity counters. Hitting pity guarantees that tier!")
+        embed.set_thumbnail(url=member.display_avatar.url)
+        await ctx.reply(embed=embed)
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Gameplay(bot))

--- a/cogs/gameplay.py
+++ b/cogs/gameplay.py
@@ -42,6 +42,9 @@ class Gameplay(commands.Cog):
             # Normal roll - check if pity guarantees a tier
             guaranteed_tier = func.check_pity_guarantee(user)
 
+            # Calculate soft pity boosts for rate increases
+            soft_pity_boosts = func.calculate_soft_pity_boost(user)
+
             query["$set"] = {"cooldown.roll": time.time() + (func.settings.COOLDOWN_BASE["roll"][1] * (1 - actived_potions.get("speed", 0)))}
 
         else:
@@ -54,6 +57,7 @@ class Gameplay(commands.Cog):
                 return await ctx.reply(f"You've used up all your `{tier}` rolls for now.")
 
             query["$inc"] = {f"roll.{tier}": -1}
+            soft_pity_boosts = None
 
         query = func.update_quest_progress(user, "ROLL", query=query)
         await func.update_user(ctx.author.id, query)
@@ -65,7 +69,21 @@ class Gameplay(commands.Cog):
 
         # Roll cards with guaranteed tier if pity was triggered, otherwise use the purchased tier or normal roll
         roll_tier = guaranteed_tier if guaranteed_tier else tier
-        cards = iufi.CardPool.roll(included=[roll_tier] if roll_tier else None, luck_rates=None if roll_tier else actived_potions.get("luck", None))
+
+        # Apply soft pity boosts for normal rolls (combine with luck potion if present)
+        if not tier and not roll_tier:
+            # Normal roll without guarantee - apply soft pity boosts
+            cards = iufi.CardPool.roll(
+                included=[roll_tier] if roll_tier else None,
+                luck_rates=actived_potions.get("luck", None),
+                soft_pity_boosts=soft_pity_boosts
+            )
+        else:
+            # Guaranteed roll or purchased roll - no soft pity
+            cards = iufi.CardPool.roll(
+                included=[roll_tier] if roll_tier else None,
+                luck_rates=None if roll_tier else actived_potions.get("luck", None)
+            )
 
         # Update pity based on rolled cards (only for normal rolls)
         if not tier:
@@ -209,22 +227,42 @@ class Gameplay(commands.Cog):
 
         user = await func.get_user(member.id)
         user_pity = user.get("pity", {})
+        soft_pity_boosts = func.calculate_soft_pity_boost(user)
 
         embed = discord.Embed(title=f"🎲 {member.display_name}'s Pity Progress", color=0x59b0c0)
 
         pity_info = []
-        for tier, threshold in func.settings.PITY_SETTINGS.items():
+        for tier, pity_config in func.settings.PITY_SETTINGS.items():
+            soft_pity = pity_config.get('soft_pity', 0)
+            hard_pity = pity_config.get('hard_pity', 0)
+            max_boost = pity_config.get('soft_pity_boost', 1.0)
             current = user_pity.get(tier, 0)
-            progress_bar_length = 20
-            filled = int((current / threshold) * progress_bar_length)
-            bar = "█" * filled + "░" * (progress_bar_length - filled)
-            percentage = (current / threshold) * 100
+            current_boost = soft_pity_boosts.get(tier, 1.0)
 
-            pity_info.append(f"**{tier.capitalize()}**: {current}/{threshold} ({percentage:.1f}%)")
-            pity_info.append(f"{bar}\n")
+            # Determine which phase user is in
+            if current >= hard_pity:
+                phase = "🔥 HARD PITY (Guaranteed!)"
+                progress_to_show = hard_pity
+                bar_percentage = 1.0
+            elif current >= soft_pity:
+                phase = f"✨ SOFT PITY (Rates boosted {current_boost:.2f}x)"
+                progress_to_show = hard_pity
+                bar_percentage = current / hard_pity
+            else:
+                phase = f"📊 Building (Soft pity at {soft_pity})"
+                progress_to_show = soft_pity
+                bar_percentage = current / soft_pity if soft_pity > 0 else 0
+
+            # Progress bar
+            progress_bar_length = 20
+            filled = int(bar_percentage * progress_bar_length)
+            bar = "█" * filled + "░" * (progress_bar_length - filled)
+
+            pity_info.append(f"**{tier.capitalize()}**: {current}/{progress_to_show}")
+            pity_info.append(f"{bar} {phase}\n")
 
         embed.description = "\n".join(pity_info)
-        embed.set_footer(text="Normal rolls increment pity counters. Hitting pity guarantees that tier!")
+        embed.set_footer(text="Soft pity: Increased rates | Hard pity: Guaranteed! | Normal rolls only.")
         embed.set_thumbnail(url=member.display_avatar.url)
         await ctx.reply(embed=embed)
 

--- a/functions.py
+++ b/functions.py
@@ -62,7 +62,7 @@ class Settings:
         self.MUSIC_NODE: Dict[str, Union[str, int]] = {}
         self.USER_BASE: Dict[str, Any] = {}
         self.COOLDOWN_BASE: Dict[str, tuple[str, int]] = {}
-        self.PITY_SETTINGS: Dict[str, int] = {}
+        self.PITY_SETTINGS: Dict[str, Dict[str, Any]] = {}
         self.DAILY_QUESTS: Dict[str, Union[str, int]] = {}
         self.WEEKLY_QUESTS: Dict[str, Union[str, int]] = {}
         self.TIERS_BASE: Dict[str, List[str, int]] = {}
@@ -431,11 +431,45 @@ async def check_wishlist(message: discord.Message, card_ids: List[str]) -> None:
             except Exception as _:
                 continue
 
+def calculate_soft_pity_boost(user: Dict[str, Any]) -> Dict[str, float]:
+    """
+    Calculate the rate boost multipliers for each tier based on soft pity progress.
+    The boost increases linearly from 1.0x at soft_pity to soft_pity_boost at hard_pity-1.
+
+    Returns: Dict of {tier: boost_multiplier}
+    """
+    user_pity = user.get("pity", {})
+    tier_hierarchy = ["rare", "epic", "legendary", "mystic", "celestial"]
+    boosts = {}
+
+    for tier in tier_hierarchy:
+        pity_config = settings.PITY_SETTINGS.get(tier, {})
+        soft_pity = pity_config.get('soft_pity', 0)
+        hard_pity = pity_config.get('hard_pity', float('inf'))
+        max_boost = pity_config.get('soft_pity_boost', 1.0)
+        current_pity = user_pity.get(tier, 0)
+
+        if current_pity >= soft_pity and current_pity < hard_pity:
+            # Calculate linear increase from 1.0x to max_boost
+            soft_pity_range = hard_pity - soft_pity
+            progress_in_soft_pity = current_pity - soft_pity
+            boost_progress = progress_in_soft_pity / soft_pity_range
+            boost = 1.0 + (max_boost - 1.0) * boost_progress
+            boosts[tier] = boost
+        elif current_pity >= hard_pity:
+            # At hard pity, apply max boost (though guarantee kicks in)
+            boosts[tier] = max_boost
+        else:
+            # Not in soft pity range
+            boosts[tier] = 1.0
+
+    return boosts
+
 def check_pity_guarantee(user: Dict[str, Any]) -> str | None:
     """
-    Check if user has hit any pity threshold and return the guaranteed tier.
+    Check if user has hit any hard pity threshold and return the guaranteed tier.
     Does NOT modify pity counters - just checks and returns the tier to guarantee.
-    Returns: guaranteed_tier (highest tier that hit pity, or None)
+    Returns: guaranteed_tier (highest tier that hit hard pity, or None)
     """
     # Get user's current pity counters
     user_pity = user.get("pity", {})
@@ -443,15 +477,16 @@ def check_pity_guarantee(user: Dict[str, Any]) -> str | None:
     # Define tier hierarchy (lowest to highest)
     tier_hierarchy = ["rare", "epic", "legendary", "mystic", "celestial"]
 
-    # Check which pity thresholds have been hit, return the highest one
+    # Check which hard pity thresholds have been hit, return the highest one
     guaranteed_tier = None
 
     for tier in tier_hierarchy:
-        pity_threshold = settings.PITY_SETTINGS.get(tier, float('inf'))
+        pity_config = settings.PITY_SETTINGS.get(tier, {})
+        hard_pity_threshold = pity_config.get('hard_pity', float('inf'))
         current_pity = user_pity.get(tier, 0)
 
-        # If this tier's pity has been reached
-        if current_pity >= pity_threshold:
+        # If this tier's hard pity has been reached
+        if current_pity >= hard_pity_threshold:
             guaranteed_tier = tier  # Keep updating to get the highest tier
 
     return guaranteed_tier

--- a/functions.py
+++ b/functions.py
@@ -62,6 +62,7 @@ class Settings:
         self.MUSIC_NODE: Dict[str, Union[str, int]] = {}
         self.USER_BASE: Dict[str, Any] = {}
         self.COOLDOWN_BASE: Dict[str, tuple[str, int]] = {}
+        self.PITY_SETTINGS: Dict[str, int] = {}
         self.DAILY_QUESTS: Dict[str, Union[str, int]] = {}
         self.WEEKLY_QUESTS: Dict[str, Union[str, int]] = {}
         self.TIERS_BASE: Dict[str, List[str, int]] = {}
@@ -94,6 +95,7 @@ class Settings:
         self.MUSIC_NODE = settings.get("MUSIC_NODE")
         self.USER_BASE = settings.get("USER_BASE")
         self.COOLDOWN_BASE = settings.get("COOLDOWN_BASE")
+        self.PITY_SETTINGS = settings.get("PITY_SETTINGS", {})
         self.DAILY_QUESTS = {k: v for k, v in settings.get("DAILY_QUESTS").items()}
         self.WEEKLY_QUESTS = {k: v for k, v in settings.get("WEEKLY_QUESTS").items()}
         self.TIERS_BASE = settings.get("TIERS_BASE")
@@ -428,3 +430,78 @@ async def check_wishlist(message: discord.Message, card_ids: List[str]) -> None:
                     await user.send(f"Your wish card has been rolled or traded by another player. {message.jump_url}")
             except Exception as _:
                 continue
+
+def check_pity_guarantee(user: Dict[str, Any]) -> str | None:
+    """
+    Check if user has hit any pity threshold and return the guaranteed tier.
+    Does NOT modify pity counters - just checks and returns the tier to guarantee.
+    Returns: guaranteed_tier (highest tier that hit pity, or None)
+    """
+    # Get user's current pity counters
+    user_pity = user.get("pity", {})
+
+    # Define tier hierarchy (lowest to highest)
+    tier_hierarchy = ["rare", "epic", "legendary", "mystic", "celestial"]
+
+    # Check which pity thresholds have been hit, return the highest one
+    guaranteed_tier = None
+
+    for tier in tier_hierarchy:
+        pity_threshold = settings.PITY_SETTINGS.get(tier, float('inf'))
+        current_pity = user_pity.get(tier, 0)
+
+        # If this tier's pity has been reached
+        if current_pity >= pity_threshold:
+            guaranteed_tier = tier  # Keep updating to get the highest tier
+
+    return guaranteed_tier
+
+def update_pity_from_cards(user: Dict[str, Any], cards: List[Any]) -> Dict[str, Any]:
+    """
+    After rolling, check the cards received and update pity accordingly.
+    - If user got a high tier card:
+      - Reset that tier's pity and all lower tiers to 0
+      - Increment all higher tiers by 1
+    - If user only got common cards, increment all pity counters by 1
+    Returns: query with pity updates
+    """
+    # Define tier hierarchy (lowest to highest)
+    tier_hierarchy = ["rare", "epic", "legendary", "mystic", "celestial"]
+
+    # Get the highest tier from the rolled cards
+    highest_tier_rolled = None
+    for card in cards:
+        card_tier = card.tier[1] if hasattr(card, 'tier') and isinstance(card.tier, tuple) else None
+        if card_tier and card_tier in tier_hierarchy:
+            if highest_tier_rolled is None:
+                highest_tier_rolled = card_tier
+            else:
+                # Compare and keep the higher tier
+                if tier_hierarchy.index(card_tier) > tier_hierarchy.index(highest_tier_rolled):
+                    highest_tier_rolled = card_tier
+
+    query = {}
+
+    if highest_tier_rolled and highest_tier_rolled != "common":
+        # User got a rare+ card
+        tier_index = tier_hierarchy.index(highest_tier_rolled)
+
+        # Reset that tier and all lower tiers to 0
+        query["$set"] = {}
+        for i in range(tier_index + 1):
+            tier_to_reset = tier_hierarchy[i]
+            query["$set"][f"pity.{tier_to_reset}"] = 0
+
+        # Increment all higher tiers by 1
+        query["$inc"] = {}
+        for i in range(tier_index + 1, len(tier_hierarchy)):
+            tier_to_increment = tier_hierarchy[i]
+            query["$inc"][f"pity.{tier_to_increment}"] = 1
+    else:
+        # User only got common cards - increment all pity counters
+        query["$inc"] = {}
+        for tier in tier_hierarchy:
+            query["$inc"][f"pity.{tier}"] = 1
+
+    return query
+

--- a/iufi/pool.py
+++ b/iufi/pool.py
@@ -198,15 +198,27 @@ class CardPool:
         return cards
     
     @classmethod
-    def roll(cls, amount: int = 3, *, included: List[str] = None, avoid: List[str] = None, luck_rates: float = None) -> List[Card]:
+    def roll(cls, amount: int = 3, *, included: List[str] = None, avoid: List[str] = None, luck_rates: float = None, soft_pity_boosts: dict = None) -> List[Card]:
         results = included if included else []
 
         drop_rates = DROP_RATES.copy()
+
+        # Apply luck potion boost
         if luck_rates:
             drop_rates = {k: v if k == 'common' else v * (1 + luck_rates) for k, v in DROP_RATES.items()}
             total = sum(drop_rates.values())
             drop_rates['common'] = 1 - (total - drop_rates['common'])
         
+        # Apply soft pity boosts (multiplicative with luck rates)
+        if soft_pity_boosts:
+            for tier, boost in soft_pity_boosts.items():
+                if tier in drop_rates and boost > 1.0:
+                    drop_rates[tier] = drop_rates[tier] * boost
+
+            # Normalize rates to sum to 1.0
+            total = sum(drop_rates.values())
+            drop_rates = {k: v / total for k, v in drop_rates.items()}
+
         if avoid:
             drop_rates = {k: v for k, v in drop_rates.items() if k not in avoid}
 

--- a/settings.json
+++ b/settings.json
@@ -29,6 +29,13 @@
             "epic": 0,
             "legendary": 0
         },
+        "pity": {
+            "rare": 0,
+            "epic": 0,
+            "legendary": 0,
+            "mystic": 0,
+            "celestial": 0
+        },
         "cooldown": {
             "roll": 0,
             "claim": 0,
@@ -48,6 +55,13 @@
                 "next_update": 0
             }
         }
+    },
+    "PITY_SETTINGS": {
+        "rare": 5,
+        "epic": 100,
+        "legendary": 300,
+        "mystic": 1500,
+        "celestial": 3000
     },
     "COOLDOWN_BASE": {
         "roll": ["🎲", 600],

--- a/settings.json
+++ b/settings.json
@@ -57,11 +57,31 @@
         }
     },
     "PITY_SETTINGS": {
-        "rare": 5,
-        "epic": 100,
-        "legendary": 300,
-        "mystic": 1500,
-        "celestial": 3000
+        "rare": {
+            "soft_pity": 5,
+            "hard_pity": 10,
+            "soft_pity_boost": 2.0
+        },
+        "epic": {
+            "soft_pity": 30,
+            "hard_pity": 60,
+            "soft_pity_boost": 3.0
+        },
+        "legendary": {
+            "soft_pity": 120,
+            "hard_pity": 200,
+            "soft_pity_boost": 4.0
+        },
+        "mystic": {
+            "soft_pity": 3000,
+            "hard_pity": 5000,
+            "soft_pity_boost": 6.0
+        },
+        "celestial": {
+            "soft_pity": 5000,
+            "hard_pity": 7500,
+            "soft_pity_boost": 8.0
+        }
     },
     "COOLDOWN_BASE": {
         "roll": ["🎲", 600],


### PR DESCRIPTION
**🎴 IUFI Card Drop Rates & Proposed Pity System**

**We give 3 cards per roll.**
Current per-card rates:
• Common — 93%
• Rare — 5%
• Epic — 0.3%
• Legendary — 0.08%
• Mystic — 0.01%
• Celestial — 0.005%

**Expected rolls to see at least one (because 3 cards per roll):**
• Rare ≈ 7 rolls
• Epic ≈ 111 rolls
• Legendary ≈ 417 rolls
• Mystic ≈ 3,334 rolls
• Celestial ≈ 6,667 rolls

---

### **⭐ Proposed Pity Settings (per roll)**

**Rare**
• Soft pity: **5**
• Hard pity: **10**

**Epic**
• Soft pity: **30**
• Hard pity: **60**

**Legendary**
• Soft pity: **120**
• Hard pity: **200**

**Mystic**
• Soft pity: **3,000**
• Hard pity: **5,000**

**Celestial**
• Soft pity: **5,000**
• Hard pity: **7,500**

---

Soft pity = rate starts scaling up.
Hard pity = guaranteed drop.