### PR TITLE
Fix/collection-gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ questions.json
 /.idea
 logs
 .venv
+/venv

--- a/cogs/developer.py
+++ b/cogs/developer.py
@@ -1,7 +1,11 @@
-import discord, iufi, psutil, asyncio
+import iufi
+import psutil
+import asyncio
+import discord
+import functions as func
 
 from discord.ext import commands
-from views import DebugView
+from views import DebugView, ConfirmView
 
 def formatBytes(bytes: int, unit: bool = False):
     if bytes <= 1_000_000_000:
@@ -21,11 +25,295 @@ class Developer(commands.Cog):
             callback=self._findsimilar
         )
         self.bot.tree.add_command(self.ctx_menu)
+    
+    async def cog_check(self, ctx: commands.Context) -> bool:
+        if ctx.author.id not in  func.settings.ADMIN_IDS:
+            raise commands.CheckFailure("You do not have permission to use this command.")
+        return True
+    
+    @commands.command(name="dev_givecandies")
+    async def givecandies(self, ctx: commands.Context, member: discord.Member, amount: int):
+        """
+        Gives a specified number of candies to a user.
+
+        The `amount` must be a positive integer.  
+        Candies are added directly to the user's inventory.  
+        If no user is specified, the candies will be given to the command caller.
+
+        **Examples:**
+        @prefix@givecandies @username 5
+        """
+        user_data = await func.get_user(member.id)
+        if not user_data:
+            return await ctx.reply("User not found.")
+        await func.update_user(member.id, {"$inc": {"candies": amount}})
+        await ctx.reply(f"{amount} candies have been given to {member.display_name}.")
+
+    @commands.command(name="dev_removecandies")
+    async def removecandies(self, ctx: commands.Context, member: discord.Member, amount: int):
+        """
+        Removes a specified number of candies from a user's inventory.
+
+        The `amount` must be a positive integer.  
+        If the user does not have enough candies, the command will fail gracefully.
+
+        **Examples:**
+        @prefix@removecandies @username 5
+        @prefix@removecandies @username 10
+        """
+        user_data = await func.get_user(member.id)
+        if not user_data:
+            return await ctx.reply("User not found.")
+        await func.update_user(member.id, {"$inc": {"candies": -amount}})
+        await ctx.reply(f"{amount} candies have been removed from {member.display_name}.")
+
+    @commands.command(name="dev_resetCooldown")
+    async def resetCooldown(self, ctx: commands.Context, member: discord.Member, cooldown: str):
+        """
+        Resets a specific cooldown for a user.
+
+        Supported cooldown types include: `roll`, `quiz`, and `mg`.  
+        Once reset, the user can immediately perform the associated action again without waiting for the cooldown period.
+
+        **Examples:**
+        @prefix@resetCooldown @username roll
+        @prefix@resetCooldown @username quiz
+        """
+        cd_types = {"roll": "roll", "quiz": "quiz_game", "mg": "match_game"}
+
+        if not (cooldown := cd_types.get(cooldown)):
+            return await ctx.reply(f"Cooldown not found. Available cooldown type: {', '.join(cd_types.keys())}")
+
+        user_data = await func.get_user(member.id)
+        if not user_data:
+            return await ctx.reply("User not found.")
+
+        await func.update_user(member.id, {"$set": {f"cooldown.{cooldown}": 0}})
+        await ctx.reply(f"{cooldown} cooldown has been reset for {member.display_name}.")
+
+    @commands.command(name="dev_resetCardTradeCooldown")
+    async def resetCardTradeCooldown(self, ctx: commands.Context, card_id: str):
+        """
+        Resets the trade cooldown for a specific card.
+
+        The `card_id` must match the identifier of the card whose cooldown is being cleared.  
+        Once reset, the card can be traded again immediately without waiting for the cooldown period.
+
+        **Examples:**
+        @prefix@resetCardTradeCooldown 1234
+        """
+        card = iufi.CardPool.get_card(card_id)
+        if not card:
+            return await ctx.reply("Card not found.")
+
+        await func.update_card(card_id, {"$set": {"last_trade_time": 0}})
+        await ctx.reply(f"Cooldown has been reset for card {card_id}.")
+
+    @commands.command(name="dev_giveCardToUser")
+    async def giveCardToUser(self, ctx: commands.Context, member: discord.Member, card_id: str):
+        """
+        Gives a specific card to a user.
+
+        The `card_id` must match the identifier of the card being awarded.  
+        If no user is specified, the card will be given to the command caller.
+
+        **Examples:**
+        @prefix@giveCardToUser @username 1234
+        """
+        card = iufi.CardPool.get_card(card_id)
+        if not card:
+            return await ctx.reply("Card not found.")
+
+        if card.owner_id:
+            return await ctx.reply("Card already owned by someone.")
+
+        user_data = await func.get_user(member.id)
+
+        if not user_data:
+            return await ctx.reply("User not found.")
+
+        if len(user_data["cards"]) >= func.settings.MAX_CARDS:
+            return await ctx.reply(f"{member.display_name} already has maximum cards.")
+
+        card.change_owner(member.id)
+        iufi.CardPool.remove_available_card(card)
+        await func.update_card(card_id, {"$set": {"owner_id": member.id}})
+        await func.update_user(member.id, {"$push": {"cards": card_id}})
+
+        await ctx.reply(f"Card {card_id} has been given to {member.display_name}.")
+
+    @commands.command(name="dev_removeCardFromUser")
+    async def removeCardFromUser(self, ctx: commands.Context, card_id: str):
+        """
+        Removes a specific card from a user's collection.
+
+        The `card_id` must match the identifier of the card to be removed.  
+        If the card does not exist or is invalid, the command will fail gracefully.
+
+        **Examples:**
+        @prefix@removeCardFromUser 1234
+        """
+        card = iufi.CardPool.get_card(card_id)
+        if not card:
+            return await ctx.reply("Card not found.")
+
+        if not card.owner_id:
+            return await ctx.reply("Card is not owned by anyone.")
+
+        card.change_owner(None)
+        iufi.CardPool.add_available_card(card)
+        await func.update_card(card_id, {"$set": {"owner_id": None, "tag": None, "frame": None, "last_trade_time": 0}})
+        await func.update_user(card.owner_id, {"$pull": {"cards": card.id}})
+
+        await ctx.reply(f"Card {card_id} has been removed from user.")
+
+    @commands.command(name="dev_giveRollToUser")
+    async def giveRollToUser(self, ctx: commands.Context, member: discord.Member, roll_type: str, amount: int = 1):
+        """
+        Grants a specified number of rolls of a given type to a user.
+
+        If no amount is provided, the default is 1 roll.  
+        The `roll_type` determines the category or kind of roll being awarded.
+
+        **Examples:**
+        @prefix@giveRollToUser @username rare 3
+        @prefix@giveRollToUser @username epic
+        """
+        roll_types = ["rare", "epic", "legendary", "mystic", "celestial"]
+
+        if roll_type not in roll_types:
+            return await ctx.reply("Roll type not found. Available roll types: " + ", ".join(roll_types))
+
+        user_data = await func.get_user(member.id)
+        if not user_data:
+            return await ctx.reply("User not found.")
+
+        await func.update_user(member.id, {"$inc": {f"roll.{roll_type}": amount}})
+        await ctx.reply(f"{amount} {roll_type} rolls have been given to {member.display_name}.")
+
+    @commands.command(name="dev_giveBirthdayCard")
+    async def giveBirthdayCard(self, ctx: commands.Context, member: discord.Member, day_number: int):
+        """
+        Gives a birthday card to a specified user for a particular day.
+
+        If no user is specified, the card will be given to the command caller.
+        The `day_number` represents the day of the month associated with the birthday card.
+
+        **Examples:**
+        @prefix@giveBirthdayCard @username 15
+        @prefix@giveBirthdayCard 20
+        """
+        if day_number < 1 or day_number > 31:
+            return await ctx.reply("Invalid day number. Must be between 1 and 31.")
+
+        user_data = await func.get_user(member.id)
+        if not user_data:
+            return await ctx.reply("User not found.")
+
+        # Convert day number to string for storage in the collection
+        day_str = str(day_number)
+
+        # Check if user already has this card
+        birthday_collection = user_data.get("birthday_collection", {})
+        if day_str in birthday_collection:
+            return await ctx.reply(f"{member.display_name} already has birthday card #{day_number}.")
+
+        # Add card to user's collection
+        update_query = {
+            "$set": {f"birthday_collection.{day_str}": True},
+            "$inc": {"birthday_cards_count": 1, "exp": 20}
+        }
+
+        await func.update_user(member.id, update_query)
+        await ctx.reply(f"Birthday card #{day_number} has been given to {member.display_name}.")
+
+    @commands.command(name="dev_setBirthdayCardsCount")
+    async def setBirthdayCardsCount(self, ctx: commands.Context, member: discord.Member, count: int):
+        """Set the birthday cards count for a user."""
+        user_data = await func.get_user(member.id)
+        if not user_data:
+            return await ctx.reply("User not found.")
+
+        # Set the birthday cards count
+        await func.update_user(member.id, {"$set": {"birthday_cards_count": count}})
+        await ctx.reply(f"Birthday cards count for {member.display_name} has been set to {count}.")
+
+    @commands.command(name="dev_quit")
+    async def quit(self, ctx: commands.Context, member: discord.Member = None):
+        """[ADMIN ONLY] Deletes a user's profile after confirmation. All cards will be converted.
+
+        If no member is specified, it will delete the profile of the user who called the command.
+
+        **Examples:**
+        @prefix@quit @username
+        @prefix@quit
+        """
+        target_user = member or ctx.author
+        user = await func.get_user(target_user.id)
+
+        # Create confirmation embed
+        embed = discord.Embed(title="⚠️ Delete Account", color=discord.Color.red())
+        embed.description = f"**WARNING: This action cannot be undone!**\n\nThis will:\n- Conver all {target_user.display_name}'s cards \n- Delete their entire profile and progress\n- Remove all inventory items and collections\n\nAre you sure you want to continue?"
+
+        # Create confirmation view
+        view = ConfirmView(ctx.author)
+        view.message = await ctx.reply(embed=embed, view=view)
+        await view.wait()
+
+        if not view.is_confirm:
+            embed.title = "❌ Account Deletion Cancelled"
+            embed.description = f"{target_user.display_name}'s account has not been deleted."
+            embed.color = discord.Color.green()
+            await view.message.edit(embed=embed, view=None)
+            return
+
+        # Convert all cards to candies (for logging purposes only)
+        converted_cards = []
+        for card_id in user["cards"]:
+            card = iufi.CardPool.get_card(card_id)
+            if card:
+                converted_cards.append(card)
+
+        card_ids = [card.id for card in converted_cards]
+        for card in converted_cards:
+            iufi.CardPool.add_available_card(card)
+
+        # Log the action
+        func.logger.info(
+            f"Admin {ctx.author.name}({ctx.author.id}) deleted the profile of {target_user.name}({target_user.id}). "
+            f"Returned {len(converted_cards)} card(s) to the available pool."
+        )
+
+        # Update the cards in the database to remove owner, tag, etc.
+        if card_ids:
+            await func.update_card(card_ids, {"$set": {"owner_id": None, "tag": None, "frame": None, "last_trade_time": 0}})
+
+        # Delete the user from the database
+        await func.USERS_DB.delete_one({"_id": target_user.id})
+
+        # Remove user from buffer cache if they exist there
+        if target_user.id in func.USERS_BUFFER:
+            del func.USERS_BUFFER[target_user.id]
+
+        # Update the confirmation message
+        embed.title = "✅ Account Deleted"
+        embed.description = f"{target_user.display_name}'s Account has been deleted. All their cards ({len(converted_cards)}) have been returned to the available pool."
+        embed.color = discord.Color.green()
+        await view.message.edit(embed=embed, view=None)
         
     @commands.command(hidden=True)
     @commands.is_owner()
     async def debug(self, ctx: commands.Context):
-        """For developer to debug"""
+        """
+        Executes developer-only debugging actions.
+
+        This command is restricted to developers and is used for testing, diagnostics, 
+        or troubleshooting within the bot environment. It should not be accessible to 
+        regular users.
+
+        **Examples:**
+        @prefix@debug
+        """
         memory = psutil.virtual_memory()
         disk = psutil.disk_usage('/')
 

--- a/cogs/gameplay.py
+++ b/cogs/gameplay.py
@@ -1,5 +1,8 @@
 import discord, iufi, time, asyncio
 import functions as func
+import random
+import io, os
+from PIL import Image, ImageFilter
 
 from discord.ext import commands
 from iufi.pool import QuestionPool as QP
@@ -9,8 +12,10 @@ from views import (
     MatchGame,
     QuizView,
     ResetAttemptView,
-    QUIZ_SETTINGS
+    QUIZ_SETTINGS,
 )
+from views.emoji_quiz import EmojiQuizView, EmojiResetAttemptView, EMOJI_QUIZ_SETTINGS
+from views.pvp import ChallengeView, get_pvp_settings, PvPMatch
 
 class Gameplay(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
@@ -159,7 +164,7 @@ class Gameplay(commands.Cog):
             return await ctx.send("There are no questions for you right now! Please try again later.")
 
         # Update the user's cooldown time
-        query = func.update_quest_progress(user, "PLAY_QUIZ_GAME", query={"$set": {"cooldown.quiz_game": time.time() + func.settings.COOLDOWN_BASE["roll"][1]}})
+        query = func.update_quest_progress(user, "PLAY_QUIZ_GAME", query={"$set": {"cooldown.quiz_game": time.time() + func.settings.COOLDOWN_BASE["quiz_game"][1]}})
         await func.update_user(ctx.author.id, query)
 
         # Create the quiz view and send the initial message
@@ -211,6 +216,122 @@ class Gameplay(commands.Cog):
         view = ShopView(ctx.author)
         view.message = await ctx.reply(embed=await view.build_embed(), view=view)
 
+    @commands.command(aliases=["eq"])
+    async def emojiquiz(self, ctx: commands.Context, category: str = None):
+        """Guess IU song or drama by emoji(s).
+
+        Optional `category` can be `song` or `drama` to restrict questions.
+
+        **Examples:**
+        @prefix@emojiquiz
+        @prefix@eq song
+        @prefix@eq drama
+        """
+        user = await func.get_user(ctx.author.id)
+        # reuse the quiz cooldown logic
+        if (retry := user.get("cooldown", {}).setdefault("quiz_game", 0)) > time.time():
+            quiz_cd = func.settings.COOLDOWN_BASE["quiz_game"][1]
+            price = max(5, int(EMOJI_QUIZ_SETTINGS['reset_price'] * ((retry - time.time()) / max(1, quiz_cd))))
+            view = EmojiResetAttemptView(ctx, user, price)
+            view.response = await ctx.reply(f"{ctx.author.mention} your emoji quiz is <t:{round(retry)}:R>. If you’d like to bypass this cooldown, you can do so by paying `🍬 {price}` candies.", delete_after=20, view=view)
+            return
+
+        # load emoji entries from JSON file
+        try:
+            import json
+            with open(os.path.join(func.ROOT_DIR, "data", "song_emojis.json"), encoding="utf8") as f:
+                entries = json.load(f)
+        except Exception:
+            entries = []
+
+        if not entries:
+            return await ctx.reply("There are no emoji entries available right now.")
+
+        # Normalize category param and filter entries if provided
+        category = category.lower() if category else None
+        if category and category not in ("song", "drama"):
+            return await ctx.reply("Invalid category. Please use `song` or `drama`.")
+
+        filtered = [e for e in entries if (not category) or (e.get("type", "song").lower() == category)]
+        if not filtered:
+            return await ctx.reply(f"No entries found for category: {category}")
+
+        num_q = min(5, len(filtered))
+        # Weighted sampling without replacement based on 'popularity' (1..10). Default popularity=5.
+        try:
+            items = filtered.copy()
+            sampled = []
+            for _ in range(num_q):
+                weights = [max(1, min(10, int(e.get("popularity", 5)))) for e in items]
+                chosen = random.choices(items, weights=weights, k=1)[0]
+                sampled.append(chosen)
+                # remove the chosen item for subsequent picks
+                items.remove(chosen)
+        except Exception:
+            # fallback to uniform sampling
+            sampled = random.sample(filtered, k=num_q)
+        # sampled is list of question dicts
+
+        # set cooldown
+        quiz_cooldown = func.settings.COOLDOWN_BASE["quiz_game"][1]
+        query = func.update_quest_progress(
+            user,
+            "PLAY_QUIZ_GAME",
+            query={"$set": {"cooldown.quiz_game": time.time() + quiz_cooldown}},
+        )
+        await func.update_user(ctx.author.id, query)
+
+        view = EmojiQuizView(ctx.author, sampled, timeout_per_question=40)
+        view.response = await ctx.reply(
+            content=f"**This game ends** <t:{round(time.time() + view.total_time)}:R>",
+            embed=view.build_embed(),
+            view=view
+        )
+
+        # start the view runner to manage per-question timeouts
+        asyncio.create_task(view.run())
+
+        await asyncio.sleep(view.total_time)
+        await view.end_game()
+
+    @commands.command()
+    async def pvp(self, ctx: commands.Context, opponent: discord.Member = None):
+        """Issue a PvP challenge. If opponent is omitted, the challenge is open for anyone to accept.
+
+        Example:
+        @prefix@pvp @user
+        @prefix@pvp
+        """
+        # create challenge view and message
+        view = ChallengeView(ctx, ctx.author, opponent, timeout=get_pvp_settings().get("challenge_timeout", 300))
+        view.message = await ctx.reply(f"{ctx.author.mention} issued a PvP challenge{' to ' + opponent.mention if opponent else ''}. Expires in <t:{round(time.time() + get_pvp_settings().get('challenge_timeout', 300))}:R>", view=view)
+
+    @commands.command(name="pvp_test", aliases=["pvptest", "pvp_auto"], hidden=True)
+    async def pvp_test(self, ctx: commands.Context):
+        """Test command: auto-start a PvP match using random cards for you and the bot, and play it through."""
+        # Ensure the card pool is loaded
+        try:
+            # pick random cards for each side
+            cards_a = iufi.CardPool.get_random_cards_for_match_game(3)
+            cards_b = iufi.CardPool.get_random_cards_for_match_game(3)
+        except Exception as e:
+            return await ctx.reply(f"Failed to pick random cards for test: {e}")
+
+        opponent = ctx.guild.me
+        settings = get_pvp_settings()
+        match = PvPMatch(ctx, ctx.author, opponent, settings)
+
+        # send a starter message to attach match outputs to
+        starter = await ctx.send(f"Starting automated PvP test: {ctx.author.mention} vs {opponent.mention}")
+        match.message = starter
+
+        # assign teams directly (bypass modal/ownership checks for testing)
+        match.teams[ctx.author.id] = cards_a
+        match.teams[opponent.id] = cards_b
+
+        # run the match and wait for it to complete
+        await match.run()
+        await ctx.send("Automated PvP test finished.")
     @commands.command(aliases=["mypity"], hidden=True)
     async def pity(self, ctx: commands.Context, member: discord.Member = None):
         """Shows pity progress for each tier. Admin only command.

--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -9,7 +9,8 @@ from views import (
 )
 from typing import (
     Dict,
-    Any
+    Any,
+    Optional,
 )
 
 DAILY_ROWS: list[str] = ["🟥", "🟧", "🟨", "🟩", "🟦", "🟪"]
@@ -22,17 +23,14 @@ WEEKLY_REWARDS: list[tuple[str, str, int]] = [
     (func.settings.TIERS_BASE.get("legendary")[0], "roll.legendary", 1),
 ]
 
-def generate_progress_bar(total, progress_percentage, filled='⣿', in_progress='⣦', empty='⣀'):
+def generate_progress_bar(total, progress_percentage, filled='█', in_progress='▓', empty='░'):
+    """Generate a simple progress bar without ANSI codes"""
     progress = int(total * progress_percentage / 100)
     filled_length = progress
-    in_progress_length = 1 if progress_percentage - filled_length > 0 else 0
+    in_progress_length = 1 if (progress_percentage % (100 / total)) > 0 and progress < total else 0
     empty_length = total - filled_length - in_progress_length
 
-    # ANSI escape code for magenta color
-    start_color = f"[0;1;{'32' if total == progress else '35'}m"
-    end_color = "[0m"
-
-    progress_bar = start_color + filled * filled_length + in_progress * in_progress_length + end_color + empty * empty_length
+    progress_bar = filled * filled_length + in_progress * in_progress_length + empty * empty_length
 
     return progress_bar
 
@@ -50,39 +48,80 @@ class Profile(commands.Cog):
         @prefix@profile
         @prefix@p IU
         """
-        if not member:
-            member = ctx.author
-        
+        member = member or ctx.author
         user = await func.get_user(member.id)
-        level, exp = func.calculate_level(user['exp'])
-        bio = user.get('profile', {}).get('bio', 'Empty Bio')
+        profile = user.get("profile", {})
+        bio =  profile.get("bio")
+        level, exp_current = func.calculate_level(user.get("exp", 0))
 
-        quiz_stats = user.get("game_state", {}).get("quiz_game", {
-            "points": 0,
-            "correct": 0,
-            "wrong": 0,
-            "timeout": 0,
-            "average_time": 0
-        })
+        exp_next = func.settings.DEFAULT_EXP
+        exp_pct = min((exp_current / exp_next * 100), 100) if exp_next > 0 else 0
 
-        card_match_stats = user.get("game_state", {}).get("match_game", {})
+        pvp = user.get("pvp", {})
+        wins = pvp.get("wins", 0)
 
-        total_questions = quiz_stats["wrong"] + quiz_stats["timeout"]
-        rank_name, rank_emoji = iufi.QuestionPool.get_rank(quiz_stats["points"])
+        embed = discord.Embed(color=discord.Color.from_rgb(255, 182, 193))
+        embed.set_author(name=f"{member.display_name}'s Profile", icon_url=member.display_avatar.url)
+        embed.set_thumbnail(url=member.display_avatar.url)
+        embed.set_footer(text=f"Member was last online {func.cal_last_online_time(user.get('last_active_time'))} ago")
 
-        embed = discord.Embed(title=f"👤 {member.display_name}'s Profile", color=discord.Color.random())
-        embed.description = f"```{bio}```" if bio else ""
-        embed.description += f"```📙 Photocards: {len(user.get('cards', []))}/{func.get_user_card_limit(user)}\n⚔️ Level: {level} ({(exp / func.settings.DEFAULT_EXP) * 100:.1f}%)\n💤 Last Active: {func.cal_last_online_time(user.get("last_active_time"), "Not Active")}```\u200b"
+        embed.description = f"╭─────────────────╮\n📝 *\"{bio}\"*\n╰─────────────────╯\n" if bio else ""
 
-        embed.add_field(name="Ranked Stats:", value=f"> <:{rank_name}:{rank_emoji}> {rank_name.title()} (`{quiz_stats['points']}`)\n> 🎯 K/DA: `{round(quiz_stats['correct'] / total_questions, 1) if total_questions else 0}` (C: `{quiz_stats['correct']}` | W: `{quiz_stats['wrong'] + quiz_stats['timeout']}`)\n> 🕒 Average Time: `{func.convert_seconds(quiz_stats['average_time'])}`", inline=True)
-        embed.add_field(name="Card Match Stats:", value="\n".join(f"> {DAILY_ROWS[int(level) - 4]} **Level {level}**: " + (f"🃏 `{stats.get('matched', 0)}` 🕒 `{func.convert_seconds(stats.get('finished_time'))}`" if (stats := card_match_stats.get(level)) else "Not attempt yet") for level in func.settings.MATCH_GAME_SETTINGS.keys()), inline=True)
+        # Level / XP
+        exp_bar = generate_progress_bar(20, exp_pct, filled="█", in_progress="▓", empty="░")
+        embed.description += func.framed_title("Levels") + "\n"
+        embed.description += (
+            "```\n"
+            f"⭐ Level {level}\n"
+            f"➤ {exp_bar} {int(exp_pct)}%\n"
+            f"➤ {exp_current:,} / {exp_next:,} XP\n"
+            "```\n"
+        )
 
-        card = iufi.CardPool.get_card(user["profile"]["main"])
-        if card and card.owner_id == user["_id"]:
-            embed.set_thumbnail(url=f"attachment://image.{card.format}")
-            return await ctx.reply(file=discord.File(await card.image_bytes(), filename=f"image.{card.format}"), embed=embed)
-        
-        await ctx.reply(embed=embed)
+        # Overview
+        cards = user.get("cards", [])
+        card_count = len(cards)
+        card_limit = func.get_user_card_limit(user)
+        candies = user.get("candies", 0)
+        collections_count = len(user.get("collections", {}))
+
+        embed.add_field(
+            name=func.framed_title("Overview"),
+            value=(
+                "```yaml\n"
+                f"Cards:       {card_count}/{card_limit}\n"
+                f"Candies:     {candies:,} 🍬\n"
+                f"Collections: {collections_count}/5\n"
+                "```"
+            ),
+            inline=True,
+        )
+
+        # Unlocks / Achievements
+        has_iufi_role = bool(func.settings.MONTHLY_LEADERBOARD_ROLE and any(role.id == func.settings.MONTHLY_LEADERBOARD_ROLE for role in member.roles))
+        embed.add_field(
+            name=func.framed_title("Unlocks"),
+            value=(
+                "```"
+                f"{'🌟' if card_count >= 100 else '⭐'} {'Card Collector':<16} {'✅' if card_count >= 100 else '🔒'}\n"
+                f"{'👑' if has_iufi_role else '💎'} {'IUFI Master':<16} {'✅' if has_iufi_role else '🔒'}\n"
+                f"{'⚔️' if wins >= 10 else '🗡️'} {'PVP Champion':<16} {'✅' if wins >= 10 else '🔒'}\n"
+                "```"
+            ),
+            inline=False,
+        )
+
+        # Showcase main card if owned
+        file = discord.utils.MISSING
+        main_id = profile.get("main")
+        card = iufi.CardPool.get_card(main_id) if main_id else None
+        if card and card.owner_id == member.id:
+            image_name = f"image.{card.format}"
+            file = discord.File(await card.image_bytes(), filename=image_name)
+            embed.set_image(url=f"attachment://{image_name}")
+            embed.add_field(name=func.framed_title("Showcase"), value=f"```{card}```", inline=False)
+
+        await ctx.reply(embed=embed, file=file)
 
     @commands.command(aliases=["sb"])
     async def setbio(self, ctx: commands.Context, *, bio: str = None):
@@ -111,6 +150,7 @@ class Profile(commands.Cog):
         @prefix@main 01
         @prefix@m 01
         """
+        card = None
         if card_id:
             card = iufi.CardPool.get_card(card_id)
             if not card:
@@ -121,7 +161,7 @@ class Profile(commands.Cog):
 
         await func.update_user(ctx.author.id, {"$set": {"profile.main": card_id}})
         embed = discord.Embed(title="👤 Set Main", color=discord.Color.random())
-        embed.description=f"```{card.tier[0]} {card.id} has been set as profile card.```" if card_id else "```Your profile card has been cleared```"
+        embed.description = (f"```{card.tier[0]} {card.id} has been set as profile card.```" if card_id and card else "```Your profile card has been cleared```")
         await ctx.reply(embed=embed)
 
     @commands.command(aliases=["ml"])
@@ -146,7 +186,7 @@ class Profile(commands.Cog):
 
         await func.update_user(ctx.author.id, {"$set": {"profile.main": card_id}})
         embed = discord.Embed(title="👤 Set Main", color=discord.Color.random())
-        embed.description=f"```{card.tier[0]} {card.id} has been set as profile card.```" if card_id else "```Your profile card has been cleared```"
+        embed.description = f"```{card.tier[0]} {card.id} has been set as profile card.```" if card_id else "```Your profile card has been cleared```"
         await ctx.reply(embed=embed)
 
     @commands.command(aliases=["cc"])
@@ -189,6 +229,7 @@ class Profile(commands.Cog):
         if not user.get("collections", {}).get(name):
             return await ctx.reply(content=f"{ctx.author.mention} no collection with the name `{name}` was found.")
         
+        card = None
         if card_id:
             card = iufi.CardPool.get_card(card_id)
             if not card:
@@ -199,10 +240,10 @@ class Profile(commands.Cog):
 
         await func.update_user(ctx.author.id, {"$set": {f"collections.{name}.{slot - 1}": card.id if card_id else None}})
 
-        func.logger.info(f"User {ctx.author.name}({ctx.author.id}) added card [{card.id}] to [{name}] collection in slot [{slot}].")
+        func.logger.info(f"User {ctx.author.name}({ctx.author.id}) added card [{card.id if card else None}] to [{name}] collection in slot [{slot}].")
 
         embed = discord.Embed(title="💕 Collection Set", color=discord.Color.random())
-        embed.description = f"```📮 {name.title()}\n🆔 {card.id.zfill(5) if card_id else None}\n🎰 {slot}\n```"
+        embed.description = f"```📮 {name.title()}\n🆔 {card.id.zfill(5) if card else None}\n🎰 {slot}\n```"
         await ctx.reply(embed=embed)
 
     @commands.command(aliases=["scl"])
@@ -273,7 +314,7 @@ class Profile(commands.Cog):
 
         user = await func.get_user(member.id)
         if len(user.get("collections", {})) == 0:
-            return await ctx.reply(content=f"{member.mention} don't have any collections.", allowed_mentions=False)
+            return await ctx.reply(content=f"{member.mention} don't have any collections.", allowed_mentions=discord.AllowedMentions.none())
 
         view = CollectionView(ctx, member, user.get("collections"))
         await view.send_msg()
@@ -289,7 +330,7 @@ class Profile(commands.Cog):
         """
         user = await func.get_user(ctx.author.id)
 
-        end_time: float = user.get("cooldown", {}).get("daily", None)
+        end_time: Optional[float] = user.get("cooldown", {}).get("daily", None)
         retry = func.cal_retry_time(end_time)
         if retry:
             return await ctx.reply(f"{ctx.author.mention} your next daily is in {retry}", delete_after=5)

--- a/functions.py
+++ b/functions.py
@@ -295,6 +295,27 @@ def match_string(input_string: str, word_list: List[str]) -> str:
 def truncate_string(text: str, length: int = 18) -> str:
     return text[:length - 3] + "..." if len(text) > length else text
 
+def _normalize_user_collections(user: Dict[str, Any]) -> None:
+    collections = user.get("collections")
+    if not isinstance(collections, dict):
+        return
+
+    for name, slots in list(collections.items()):
+        if isinstance(slots, list):
+            continue
+        if not isinstance(slots, dict):
+            collections[name] = [None] * 6
+            continue
+
+        # Heal legacy/corrupted in-memory shape where slots became a dict with numeric keys.
+        fixed_slots = [None] * 6
+        for key, card_id in slots.items():
+            if str(key).isdigit():
+                idx = int(key)
+                if 0 <= idx < 6:
+                    fixed_slots[idx] = card_id
+        collections[name] = fixed_slots
+
 async def get_user(user_id: int, *, insert: bool = True) -> Dict[str, Any]:
     user = USERS_BUFFER.get(user_id)
     if not user:
@@ -303,6 +324,7 @@ async def get_user(user_id: int, *, insert: bool = True) -> Dict[str, Any]:
             await USERS_DB.insert_one({"_id": user_id, **settings.USER_BASE})
 
         user = USERS_BUFFER[user_id] = user if user else copy.deepcopy(settings.USER_BASE) | {"_id": user_id}
+    _normalize_user_collections(user)
     return user
 
 def update_quest_progress(user: Dict[str, Any], completed_quests: Union[str, List[str]], progress: int = 1, *, query: Dict[str, Any] = None) -> Dict[str, Any]:
@@ -464,42 +486,77 @@ async def update_user(user_id: int, data: dict) -> None:
                 data.setdefault('$inc', {})[monthly_points_key] = data['$inc'].get(key, 0)
                 data.setdefault('$set', {})[last_update_key] = now_ts
 
+    def _is_index(part: str) -> bool:
+        return part.isdigit()
+
+    def _ensure_list_index(lst: list, idx: int, default_value=None) -> None:
+        while len(lst) <= idx:
+            lst.append(default_value)
+
     # Proceed with the original in-memory merging logic
     for mode, action in data.items():
         for key, value in action.items():
             cursors = key.split('.')
 
             nested_user = user
-            for c in cursors[:-1]:
+            for idx, c in enumerate(cursors[:-1]):
+                next_cursor = cursors[idx + 1]
+
+                if isinstance(nested_user, list):
+                    if not _is_index(c):
+                        break
+
+                    list_idx = int(c)
+                    default_container = [] if _is_index(next_cursor) else {}
+                    _ensure_list_index(nested_user, list_idx, None)
+                    if not isinstance(nested_user[list_idx], (dict, list)):
+                        nested_user[list_idx] = default_container
+                    nested_user = nested_user[list_idx]
+                    continue
+
                 nxt = nested_user.get(c)
-                if not isinstance(nxt, dict):
-                    nxt = {}
+                if not isinstance(nxt, (dict, list)):
+                    nxt = [] if _is_index(next_cursor) else {}
                     nested_user[c] = nxt
                 nested_user = nxt
 
+            last_cursor = cursors[-1]
+
             if mode == "$set":
-                try:
-                    nested_user[cursors[-1]] = value
-                except TypeError:
-                    nested_user[int(cursors[-1])] = value
+                if isinstance(nested_user, list) and _is_index(last_cursor):
+                    list_idx = int(last_cursor)
+                    _ensure_list_index(nested_user, list_idx, None)
+                    nested_user[list_idx] = value
+                else:
+                    nested_user[last_cursor] = value
 
             elif mode == "$unset":
-                nested_user.pop(cursors[-1], None)
+                if isinstance(nested_user, list) and _is_index(last_cursor):
+                    list_idx = int(last_cursor)
+                    if 0 <= list_idx < len(nested_user):
+                        nested_user[list_idx] = None
+                else:
+                    nested_user.pop(last_cursor, None)
 
             elif mode == "$inc":
-                nested_user[cursors[-1]] = nested_user.get(cursors[-1], 0) + value
+                if isinstance(nested_user, list) and _is_index(last_cursor):
+                    list_idx = int(last_cursor)
+                    _ensure_list_index(nested_user, list_idx, 0)
+                    nested_user[list_idx] = (nested_user[list_idx] or 0) + value
+                else:
+                    nested_user[last_cursor] = nested_user.get(last_cursor, 0) + value
 
             elif mode == "$push":
                 # Check if the value contains $each
                 if isinstance(value, dict) and "$each" in value:
-                    nested_user.setdefault(cursors[-1], []).extend(value["$each"])
+                    nested_user.setdefault(last_cursor, []).extend(value["$each"])
                 else:
-                    nested_user.setdefault(cursors[-1], []).append(value)
+                    nested_user.setdefault(last_cursor, []).append(value)
 
             elif mode == "$pull":
-                if cursors[-1] in nested_user:
+                if last_cursor in nested_user:
                     value = value.get("$in", []) if isinstance(value, dict) else [value]
-                    nested_user[cursors[-1]] = [item for item in nested_user[cursors[-1]] if item not in value]
+                    nested_user[last_cursor] = [item for item in nested_user[last_cursor] if item not in value]
 
             else:
                 raise ValueError(f"Invalid mode: {mode}")

--- a/functions.py
+++ b/functions.py
@@ -1,4 +1,4 @@
-import os, time, copy, json, random, logging, discord
+import os, time, copy, json, random, logging, discord, Levenshtein
 
 from motor.motor_asyncio import (
     AsyncIOMotorClient,
@@ -75,6 +75,13 @@ class Settings:
         self.BUG_REPORT_CHANNEL_ID: int = 0
         self.OPUS_PATH: str = ""
         self.LOGGING: Dict[Union[str, Dict[str, Union[str, bool]]]] = {}
+        self.PVP_REWARDS_ENABLED: bool = False
+        self.GIVE_REWARD_CARD: bool = False
+        self.MONTHLY_LEADERBOARD_ROLE: int = 0
+        # Newly added defaults so callers can reference them directly without getattr
+        self.PVP_SETTINGS: Dict[str, Any] = {}
+        self.REWARD_CARD_PROBABILITIES: Dict[str, Any] = {}
+        self.PERFECT_CROWN_TREASURY_CARDS: Dict[str, List[str]] = {}
 
     def load(self):
         settings = open_json("settings.json")
@@ -108,6 +115,12 @@ class Settings:
         self.BUG_REPORT_CHANNEL_ID = settings.get("BUG_REPORT_CHANNEL_ID")
         self.OPUS_PATH = settings.get("OPUS_PATH")
         self.LOGGING = settings.get("LOGGING", {})
+        self.PVP_REWARDS_ENABLED = settings.get("PVP_REWARDS_ENABLED", True)
+        self.GIVE_REWARD_CARD = settings.get("GIVE_REWARD_CARD", True)
+        self.MONTHLY_LEADERBOARD_ROLE = settings.get("MONTHLY_LEADERBOARD_ROLE", 0)
+        self.PVP_SETTINGS = settings.get("PVP_SETTINGS", {})
+        self.REWARD_CARD_PROBABILITIES = settings.get("REWARD_CARD_PROBABILITIES", {})
+        self.PERFECT_CROWN_TREASURY_CARDS = settings.get("PERFECT_CROWN_TREASURY_CARDS", {})
 
 tokens: TOKEN = TOKEN()
 settings: Settings = Settings()
@@ -152,15 +165,31 @@ def cal_retry_time(end_time: float, default: str = None) -> str | None:
     return (f"{hours}h " if hours > 0 else "") + f"{minutes}m {seconds}s"
 
 def cal_last_online_time(start_time: float, default: str = "") -> str | None:
+    """
+    Return a compact two-unit representation of how long ago `start_time` was.
+
+    Formats:
+      - If >= 1 day: "Xd Yh" (days and hours)
+      - Else: "Xh Ym" (hours and minutes)
+
+    If `start_time` is falsy or in the future, returns `default`.
+    """
     if not start_time or start_time > (current_time := time.time()):
         return default
 
-    duration_since_start: float = int(current_time - start_time)
+    # total seconds elapsed
+    total_seconds = int(current_time - start_time)
 
-    minutes, seconds = divmod(duration_since_start, 60)
-    hours, minutes = divmod(minutes, 60)
+    # If duration is at least 1 day, show days and hours
+    days = total_seconds // 86_400
+    if days >= 1:
+        hours = (total_seconds % 86_400) // 3600
+        return f"{days}d {hours}h"
 
-    return (f"{hours}h " if hours > 0 else "") + f"{minutes}m {seconds}s"
+    # Otherwise show hours and minutes
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    return f"{hours}h {minutes}m"
 
 def calculate_level(exp: int) -> tuple[int, int]:
     level = 0
@@ -202,6 +231,35 @@ def clean_text(input_text: str, allow_spaces: bool = True, convert_to_lower: boo
         cleaned_text = cleaned_text.lower()
     
     return cleaned_text
+
+def jac_similarity(str1: str, str2: str) -> float:
+    """
+    Calculate Jaccard similarity between two strings based on character sets.
+    Returns a float between 0 and 1, where 1 means identical character sets.
+    """
+    if not str1 or not str2:
+        return 0.0
+
+    set1 = set(str1.lower())
+    set2 = set(str2.lower())
+
+    intersection = len(set1.intersection(set2))
+    union = len(set1.union(set2))
+
+    return intersection / union if union > 0 else 0.0
+
+def lev_similarity(str1: str, str2: str) -> float:
+    """
+    Calculate normalized Levenshtein similarity between two strings.
+    Returns a float between 0 and 1, where 1 means identical strings.
+    """
+    if not str1 or not str2:
+        return 0.0
+
+    distance = Levenshtein.distance(str1.lower(), str2.lower())
+    max_len = max(len(str1), len(str2))
+
+    return 1 - (distance / max_len) if max_len > 0 else 0.0
 
 def get_week_unix_timestamps() -> tuple[float, float]:
     today = date.today()
@@ -257,7 +315,13 @@ def update_quest_progress(user: Dict[str, Any], completed_quests: Union[str, Lis
     for quest_type in settings.USER_BASE["quests"].keys():
         user_quest = user.copy().get("quests", {}).get(quest_type, copy.deepcopy(settings.USER_BASE["quests"][quest_type]))
 
-        QUESTS_BASE: Dict[str, Any] = getattr(settings, f"{quest_type.upper()}_QUESTS", None)
+        # Use direct attribute access for quest bases instead of getattr
+        if quest_type.lower() == 'daily':
+            QUESTS_BASE: Dict[str, Any] = settings.DAILY_QUESTS
+        elif quest_type.lower() == 'weekly':
+            QUESTS_BASE: Dict[str, Any] = settings.WEEKLY_QUESTS
+        else:
+            QUESTS_BASE: Dict[str, Any] = {}
         if not QUESTS_BASE:
             continue
         
@@ -370,13 +434,48 @@ async def update_user(user_id: int, data: dict) -> None:
     user = await get_user(user_id)
     data.setdefault('$set', {})['last_active_time'] = time.time()
 
+    # Auto-augment monthly counters for common stats so callers don't need to update monthly fields everywhere.
+    # We'll look at $inc entries and duplicate them into monthly fields where appropriate and set last-update timestamps.
+    now_ts = time.time()
+    incs = data.get('$inc', {})
+    if incs:
+        # Handle top-level exp increments -> monthly.exp and last update
+        if 'exp' in incs:
+            data.setdefault('$inc', {})['monthly.exp'] = data['$inc'].get('exp', 0)
+            data.setdefault('$set', {})['monthly.exp_last_update'] = now_ts
+
+        # Handle PVP increments (pvp.wins, pvp.losses, pvp.total_matches)
+        for key in list(incs.keys()):
+            if key.startswith('pvp.'):
+                suffix = key.split('.', 1)[1]
+                monthly_key = f"monthly.pvp.{suffix}"
+                data.setdefault('$inc', {})[monthly_key] = data['$inc'].get(key, 0)
+                data.setdefault('$set', {})['monthly.pvp_last_update'] = now_ts
+
+        # Handle game_state.<game>.points increments (music, mv_guess, quiz, emoji etc.)
+        for key in list(incs.keys()):
+            if key.count('.') >= 2 and key.split('.')[0] == 'game_state' and key.split('.')[-1] == 'points':
+                # e.g. game_state.music_game.points -> game_state.music_game.monthly_points
+                # (parent path must exclude `points`; otherwise Mongo conflicts: points vs points.monthly_points)
+                parts = key.split('.')
+                game_path = '.'.join(parts[:-1])
+                monthly_points_key = f"{game_path}.monthly_points"
+                last_update_key = f"{game_path}.last_update"
+                data.setdefault('$inc', {})[monthly_points_key] = data['$inc'].get(key, 0)
+                data.setdefault('$set', {})[last_update_key] = now_ts
+
+    # Proceed with the original in-memory merging logic
     for mode, action in data.items():
         for key, value in action.items():
-            cursors = key.split(".")
+            cursors = key.split('.')
 
             nested_user = user
             for c in cursors[:-1]:
-                nested_user = nested_user.setdefault(c, {})
+                nxt = nested_user.get(c)
+                if not isinstance(nxt, dict):
+                    nxt = {}
+                    nested_user[c] = nxt
+                nested_user = nxt
 
             if mode == "$set":
                 try:
@@ -540,3 +639,44 @@ def update_pity_from_cards(user: Dict[str, Any], cards: List[Any]) -> Dict[str, 
 
     return query
 
+
+def framed_title(title: str, total_length: int = 25) -> str:
+    """
+    Create a single-line framed title like:
+    ╔═══ Your Title Here ═══╗
+
+    :param title: The text to display inside the frame.
+    :param total_length: The total desired length of the final string.
+    :return: A formatted string with box-drawing characters.
+    """
+    if not isinstance(title, str):
+        title = str(title) if title is not None else ""
+    if total_length < 6:
+        raise ValueError("total_length must be at least 6 to render a valid frame.")
+
+    left_corner = "╔"
+    right_corner = "╗"
+    fill_char = "═"
+
+    # Add single spaces around the title for readability
+    inner = f" {title} "
+    inner_len = len(inner)
+
+    # The total space available for fill characters on both sides
+    available = total_length - len(left_corner) - len(right_corner) - inner_len
+
+    if available < 0:
+        # If the title is too long, we truncate (you could also choose to expand instead)
+        # Here we trim the title to fit exactly.
+        trim_len = total_length - len(left_corner) - len(right_corner) - 2  # account for spaces
+        if trim_len <= 0:
+            raise ValueError("total_length is too small to fit any title content.")
+        inner = f" {title[:trim_len]} "
+        inner_len = len(inner)
+        available = total_length - len(left_corner) - len(right_corner) - inner_len
+
+    # Distribute fill characters on both sides
+    left_fill = available // 2
+    right_fill = available - left_fill
+
+    return f"**{left_corner}{fill_char * left_fill}{inner}{fill_char * right_fill}{right_corner}**"

--- a/iufi/music.py
+++ b/iufi/music.py
@@ -133,6 +133,9 @@ class Player(VoiceProtocol):
         self._message: Optional[Message] = None
         self._current: Track = None
         self._history: List[str] = []
+        # Keep history proportional to pool size.
+        # For tiny pools this can be 0, which intentionally disables history
+        # so tracks can repeat instead of causing empty-availability edge cases.
         self._max_history_size: int = int(len(MusicPool._questions) * .7)
         self._is_skipping: bool = False
 
@@ -152,24 +155,40 @@ class Player(VoiceProtocol):
             # Prevent AFK player
             if (time.time() - self.last_answer_time) >= 600:
                 return await self.teardown()
-            
-            # Fetch a random track, checking history
-            track = await MusicPool.get_random_question(self._history)
-            if not track:
-                return await self.teardown()
 
-            if not track.is_loaded:
+            # Try a few candidates in case some tracks are unavailable (e.g. YouTube sign-in required)
+            track: Optional[Track] = None
+            for _ in range(5):
+                candidate = await MusicPool.get_random_question(self._history)
+                if not candidate:
+                    break
+
+                if not candidate.is_loaded:
+                    await candidate.load_data()
+
+                # Skip invalid metadata and keep moving
+                if (not candidate.is_loaded) or candidate.duration <= 0:
+                    self.add_to_history(candidate)
+                    continue
+
+                # Determine a random start time within the track's duration
+                self.track_start_time = random.uniform(candidate.duration * 0.2, candidate.duration * 0.6)
+
                 try:
-                    await track.load_data()
-                except Exception as _:
-                    return await self.do_next();
+                    source = await candidate.source(self.track_start_time)
+                except Exception:
+                    self.add_to_history(candidate)
+                    continue
 
-            # Determine a random start time within the track's duration
-            self.track_start_time = random.uniform(track.duration * 0.2, track.duration * 0.6)
+                # Set the current track and play it
+                track = candidate
+                self._current = track
+                self.voice_client.play(source, after=lambda e: self.bot.loop.create_task(self.skip_song()))
+                break
 
-            # Set the current track and play it
-            self._current = track
-            self.voice_client.play(await track.source(self.track_start_time), after=lambda e: self.bot.loop.create_task(self.skip_song()))
+            if not track:
+                func.logger.warning("No playable music track found. Tearing down music player.")
+                return await self.teardown()
             
             # Update guesser, history and track usage time
             self.guesser = None
@@ -212,54 +231,120 @@ class Player(VoiceProtocol):
 
         user = await func.get_user(message.author.id)
         last_points: int = user.get("game_state", {}).get("music_game", {}).get("points", 0)
+        new_points = last_points + points
 
-        # Prepare the query for updating points and rewards
+        # Prepare the query for updating points
         query: Dict[str, Any] = {"$inc": {"game_state.music_game.points": points}}
-        rewards: Dict[str, Dict[str, Union[str, int]]] = {}
+        
+        # Feature flag: Use reward card system or traditional rewards
+        use_reward_card = func.settings.GIVE_REWARD_CARD
 
-        # Calculate milestones and rewards
-        for game_reward in func.settings.MUSIC_GAME_SETTINGS["GAME_REWARDS"]:
-            last_milestone = last_points // game_reward["amount"]
-            current_milestone = (last_points + points) // game_reward["amount"]
+        if not use_reward_card:
+            # Traditional reward system (milestone rewards)
+            rewards: Dict[str, Dict[str, Union[str, int]]] = {}
+            
+            # Calculate milestones and rewards
+            for game_reward in func.settings.MUSIC_GAME_SETTINGS["GAME_REWARDS"]:
+                last_milestone = last_points // game_reward["amount"]
+                current_milestone = new_points // game_reward["amount"]
 
-            # Check if the user has reached a new milestone
-            if current_milestone > last_milestone:
-                for reward in game_reward["rewards"]:
-                    if isinstance(reward[0], list):
-                        reward = random.choice(reward)
-                    r_emoji, r_name, r_amount = reward
+                # Check if the user has reached a new milestone
+                if current_milestone > last_milestone:
+                    for reward in game_reward["rewards"]:
+                        if isinstance(reward[0], list):
+                            reward = random.choice(reward)
+                        r_emoji, r_name, r_amount = reward
 
-                    # Update the query for rewards
-                    query["$inc"][r_name] = query["$inc"].get(r_name, 0) + r_amount
+                        # Update the query for rewards
+                        query["$inc"][r_name] = query["$inc"].get(r_name, 0) + r_amount
 
-                    # Update rewards with emoji and amount
-                    rewards[r_name] = rewards.setdefault(r_name, {"emoji": r_emoji, "amount": 0})
-                    rewards[r_name]["amount"] += r_amount
+                        # Update rewards with emoji and amount
+                        rewards[r_name] = rewards.setdefault(r_name, {"emoji": r_emoji, "amount": 0})
+                        rewards[r_name]["amount"] += r_amount
 
-        # Prepare reward message
-        reward_message = ""
-        for reward_name, reward_data in rewards.items():
-            r_display_name = reward_name.split(".")
-            r_emoji, r_amount = reward_data["emoji"], reward_data["amount"]
+            # Prepare reward message
+            reward_message = ""
+            for reward_name, reward_data in rewards.items():
+                r_display_name = reward_name.split(".")
+                r_emoji, r_amount = reward_data["emoji"], reward_data["amount"]
 
-            if len(r_display_name) == 1:
-                reward_message += f"{r_emoji} {r_display_name[0].title():<18} x{reward_data["amount"]}\n"
-            else:
-                reward_parts = r_display_name[1].split("_")
-                format_name = f"{reward_parts[0].title()}" if len(reward_parts) == 1 else f"{reward_parts[0].title()} {reward_parts[1].upper()}"
-                reward_message += f"{r_emoji} {f'{format_name} {r_display_name[0].title()}':<18} x{r_amount}\n"
+                if len(r_display_name) == 1:
+                    reward_message += f"{r_emoji} {r_display_name[0].title():<18} x{r_amount}\n"
+                else:
+                    reward_parts = r_display_name[1].split("_")
+                    format_name = f"{reward_parts[0].title()}" if len(reward_parts) == 1 else f"{reward_parts[0].title()} {reward_parts[1].upper()}"
+                    reward_message += f"{r_emoji} {f'{format_name} {r_display_name[0].title()}':<18} x{r_amount}\n"
 
-        # Update user data in the database
-        query = func.update_quest_progress(user, "PLAY_MUSIC_QUIZ_GAME", progress=points, query=query)
-        await func.update_user(message.author.id, query)
-        func.logger.info(f"User {message.author.name}({message.author.id}) earned {points} points in the music quiz by answering in {time_used:.2f} seconds.")
+            # Update user data in the database
+            query = func.update_quest_progress(user, "PLAY_MUSIC_QUIZ_GAME", progress=points, query=query)
+            await func.update_user(message.author.id, query)
+            func.logger.info(f"User {message.author.name}({message.author.id}) earned {points} points in the music quiz by answering in {time_used:.2f} seconds.")
 
-        # Create and send the response embed
-        embed = Embed(title="Music Quiz Reward", description=f"```{reward_message}```", color=Color.random()) if reward_message else None
-        await message.reply(
-            random.choice(MESSAGES).format(time=func.convert_seconds(time_used), points=points),
-            embed=embed
-        )
+            # Create and send the response embed
+            embed = Embed(title="Music Quiz Reward", description=f"```{reward_message}```", color=Color.random()) if reward_message else None
+            await message.reply(
+                random.choice(MESSAGES).format(time=func.convert_seconds(time_used), points=points),
+                embed=embed
+            )
+        else:
+            # Reward card system
+            # Update user data in the database (no traditional rewards)
+            query = func.update_quest_progress(user, "PLAY_MUSIC_QUIZ_GAME", progress=points, query=query)
+            await func.update_user(message.author.id, query)
+            func.logger.info(f"User {message.author.name}({message.author.id}) earned {points} points in the music quiz by answering in {time_used:.2f} seconds.")
+            
+            # Send basic message
+            await message.reply(
+                random.choice(MESSAGES).format(time=func.convert_seconds(time_used), points=points)
+            )
+            
+            # Check if we should give a reward card based on point thresholds
+            probs_config = func.settings.REWARD_CARD_PROBABILITIES or {}
+            probs_config = probs_config.get("MUSIC_QUIZ", {})
+            selected_probs = None
+            
+            # Find if user has crossed a threshold (every 10, 100, etc.)
+            for threshold_str in sorted(probs_config.keys(), key=int):
+                threshold = int(threshold_str)
+                # Check if this answer caused them to cross a threshold
+                if last_points < threshold <= new_points:
+                    selected_probs = probs_config[threshold_str]
+                    break
+            
+            if selected_probs:
+                try:
+                    # Import RewardCardView from views package
+                    from views.reward_card import RewardCardView
+                    
+                    # Create and send reward card view
+                    reward_view = RewardCardView(None, message.author, selected_probs, initial_cost=10, cost_currency_field="candies", timeout=120)
+                    await reward_view._roll_card()
+                    
+                    reward_embed = reward_view.build_embed()
+                    file = None
+                    if reward_view.current_card:
+                        try:
+                            img_bytes = await reward_view.current_card.image_bytes()
+                            filename = f"{reward_view.current_card.id}.webp"
+                            file = discord.File(img_bytes, filename=filename)
+                            reward_embed.set_image(url=f"attachment://{filename}")
+                        except Exception:
+                            file = None
+                    
+                    reward_content = f"**{message.author.mention} This reward ends <t:{reward_view.expires_at}:R>**\n🎁 Card reward for reaching {new_points} points!"
+                    reward_msg = await self._text_channel.send(
+                        content=reward_content,
+                        embed=reward_embed,
+                        file=file,
+                        view=reward_view
+                    )
+                    reward_view.message = reward_msg
+                except Exception:
+                    # Fail silently but log
+                    try:
+                        func.logger.exception("Failed to present music quiz reward card view")
+                    except:
+                        pass
 
     async def connect(self, *, reconnect: bool, timeout: float, self_deaf: bool = False, self_mute: bool = False) -> None:
         await self.channel.connect(reconnect=reconnect, timeout=timeout, self_deaf=self_deaf, self_mute=self_mute)
@@ -307,7 +392,10 @@ class Player(VoiceProtocol):
     
     def add_to_history(self, track: Track):
         """Add a track ID to the history, removing the oldest entry if the history exceeds half the size of the MusicPool's questions."""
-        if len(self._history) >= self._max_history_size:
+        if self._max_history_size <= 0:
+            return
+
+        if len(self._history) >= self._max_history_size and self._history:
             self._history.pop(0)  # Remove the oldest element
         self._history.append(track.id)  # Add the new track id
 

--- a/iufi/objects.py
+++ b/iufi/objects.py
@@ -51,6 +51,36 @@ YTDL_FORMAT_OPTIONS: Dict[str, str] = {
     'source_address': '0.0.0.0',
 }
 
+# Optional authentication for restricted YouTube videos.
+# Configure via environment variables in .env:
+# - YTDLP_COOKIE_FILE=/absolute/path/to/cookies.txt
+# - YTDLP_COOKIES_FROM_BROWSER=firefox[:profile[:keyring[:container]]]
+if cookie_file := os.getenv("YTDLP_COOKIE_FILE"):
+    YTDL_FORMAT_OPTIONS["cookiefile"] = cookie_file
+
+if cookies_from_browser := os.getenv("YTDLP_COOKIES_FROM_BROWSER"):
+    YTDL_FORMAT_OPTIONS["cookiesfrombrowser"] = tuple(
+        part.strip() for part in cookies_from_browser.split(":") if part.strip()
+    )
+
+# Optional JS challenge runtime setup for modern YouTube extraction.
+# Examples:
+# - YTDLP_JS_RUNTIMES=node
+# - YTDLP_JS_RUNTIMES=deno:/usr/bin/deno,node
+if js_runtimes := os.getenv("YTDLP_JS_RUNTIMES"):
+    YTDL_FORMAT_OPTIONS["js_runtimes"] = [
+        item.strip() for item in js_runtimes.split(",") if item.strip()
+    ]
+
+# Optional remote EJS component source.
+# Examples:
+# - YTDLP_REMOTE_COMPONENTS=ejs:github
+# - YTDLP_REMOTE_COMPONENTS=ejs:npm
+if remote_components := os.getenv("YTDLP_REMOTE_COMPONENTS"):
+    YTDL_FORMAT_OPTIONS["remote_components"] = [
+        item.strip() for item in remote_components.split(",") if item.strip()
+    ]
+
 YTDL = yt_dlp.YoutubeDL(YTDL_FORMAT_OPTIONS)
 
 class CardObject:
@@ -472,7 +502,7 @@ class Track():
         self.data: Dict[str, Any] = data
         self.is_updated: bool = False
 
-    async def load_data(self, *, stream=False) -> Dict[str, Any]:
+    async def load_data(self, *, stream=False) -> bool:
         try:
             loop = asyncio.get_event_loop()
             data = await loop.run_in_executor(None, lambda: YTDL.extract_info(self.url, download=not stream))
@@ -485,17 +515,25 @@ class Track():
                 "release_year": data.get("release_year", "----")
             }
             self.is_updated = True
+            return True
         
         except Exception as e:
             func.logger.info("An exception occurred while loading track info from YouTube.", exc_info=e)
+            return False
     
-    async def get_audio_file_path(self) -> Optional[str]:
+    async def get_audio_file_path(self, retries: int = 1) -> Optional[str]:
         for item in os.listdir(func.MUSIC_TRACKS_FOLDER):
             if os.path.splitext(item)[0] == self.id:
                 return os.path.join(func.MUSIC_TRACKS_FOLDER, item)
-        
-        await self.load_data()
-        return self.get_audio_file_path(self)
+
+        if retries <= 0:
+            return None
+
+        loaded = await self.load_data()
+        if not loaded:
+            return None
+
+        return await self.get_audio_file_path(retries=retries - 1)
 
     def check_answer(self, answer: str, threshold: float = .9) -> bool:
         answer = answer.lower()
@@ -530,7 +568,11 @@ class Track():
         self.data[key] = self.data.get(key, 0) + 1
 
     async def source(self, start: float = 0) -> FFmpegPCMAudio:
-        return FFmpegPCMAudio(await Track.get_audio_file_path(self), options=f'-vn -ss {start}')
+        audio_file_path = await Track.get_audio_file_path(self)
+        if not audio_file_path:
+            raise IUFIException(f"Audio source unavailable for track {self.id}")
+
+        return FFmpegPCMAudio(audio_file_path, options=f'-vn -ss {start}')
     
     @property
     def is_loaded(self) -> bool:

--- a/iufi/pool.py
+++ b/iufi/pool.py
@@ -123,7 +123,12 @@ class CardPool:
                         UpdateOne({"_id": card_id}, {"$set": {"stars": stars}})
                     )
 
-                cls.add_card(tier=category, **card_data)
+                card_kwargs = {
+                    key: value
+                    for key, value in card_data.items()
+                    if key in {"owner_id", "stars", "tag", "frame", "last_trade_time"}
+                }
+                cls.add_card(_id=card_id, tier=category, **card_kwargs)
                 processed += 1
 
                 if total_images > 0 and (processed % progress_step == 0 or processed == total_images):

--- a/iufi/pool.py
+++ b/iufi/pool.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+import time
 import functions as func
 
 from collections import Counter
 from random import randint
+from pymongo import UpdateOne
 
 from typing import (
     Optional,
@@ -65,26 +67,89 @@ class CardPool:
 
     @classmethod
     async def fetch_data(cls) -> None:
+        start_at = time.perf_counter()
+
         # Fetch all card data from the database
         all_card_data: Dict[str, Any] = {doc["_id"]: doc async for doc in func.CARDS_DB.find()}
+        missing_docs: List[Dict[str, Any]] = []
+        stars_backfill_ops: List[UpdateOne] = []
+
+        categories = [category for category in os.listdir(func.CARDS_FOLDER) if not category.startswith(".")]
+        category_images: Dict[str, List[str]] = {}
+        total_images = 0
+
+        for category in categories:
+            images = [
+                image
+                for image in os.listdir(os.path.join(func.CARDS_FOLDER, category))
+                if not image.startswith(".")
+            ]
+            category_images[category] = images
+            total_images += len(images)
+
+        func.logger.info(
+            f"Startup: discovered {total_images} card image files across {len(category_images)} tiers."
+        )
+        processed = 0
+        progress_step = 1000
 
         # Process existing cards in the cards folder
-        for category in os.listdir(func.CARDS_FOLDER):
-            if category.startswith("."):
-                continue
+        for category, images in category_images.items():
+            category_start = time.perf_counter()
 
-            for image in os.listdir(os.path.join(func.CARDS_FOLDER, category)):
-                if image.startswith("."):
-                    continue
+            for image in images:
 
                 card_id = os.path.splitext(image)[0]
-                card_data = all_card_data.get(card_id, {"_id": card_id})
+                card_data = all_card_data.get(card_id)
 
-                # Initialize stars if not present
-                if "stars" not in card_data:
-                    card_data["stars"] = (stars := randint(1, 5))
-                    await func.update_card(card_id, {"$set": {"stars": stars}})
+                # First run on a fresh DB: seed missing card documents in bulk
+                if not card_data:
+                    stars = randint(1, 5)
+                    card_data = {
+                        "_id": card_id,
+                        "stars": stars,
+                        "owner_id": None,
+                        "tag": None,
+                        "frame": None,
+                        "last_trade_time": 0,
+                    }
+                    missing_docs.append(card_data.copy())
+
+                # Existing doc without stars: backfill stars in one bulk update
+                elif "stars" not in card_data:
+                    stars = randint(1, 5)
+                    card_data["stars"] = stars
+                    stars_backfill_ops.append(
+                        UpdateOne({"_id": card_id}, {"$set": {"stars": stars}})
+                    )
+
                 cls.add_card(tier=category, **card_data)
+                processed += 1
+
+                if total_images > 0 and (processed % progress_step == 0 or processed == total_images):
+                    elapsed = time.perf_counter() - start_at
+                    progress_pct = (processed / total_images) * 100
+                    func.logger.info(
+                        f"Card pool progress: {processed}/{total_images} ({progress_pct:.1f}%) in {elapsed:.1f}s"
+                    )
+
+            category_elapsed = time.perf_counter() - category_start
+            func.logger.info(
+                f"Card tier loaded: {category} ({len(images)} cards, {category_elapsed:.1f}s)"
+            )
+
+        if missing_docs:
+            await func.CARDS_DB.insert_many(missing_docs, ordered=False)
+            func.logger.info(f"Seeded {len(missing_docs)} missing card documents.")
+
+        if stars_backfill_ops:
+            await func.CARDS_DB.bulk_write(stars_backfill_ops, ordered=False)
+            func.logger.info(f"Backfilled stars for {len(stars_backfill_ops)} card documents.")
+
+        total_elapsed = time.perf_counter() - start_at
+        func.logger.info(
+            f"Startup: card pool ready. loaded={len(cls._cards)} elapsed={total_elapsed:.1f}s"
+        )
 
     @classmethod
     async def process_new_cards(cls) -> None:
@@ -352,7 +417,12 @@ class MusicPool:
         if not available_questions:
             return None
 
-        return choice(available_questions)
+        # Weight songs by likes (more likes = higher chance of being played)
+        # Add 1 to each like count to ensure songs with 0 likes can still be selected
+        weights = [track.likes + 1 for track in available_questions]
+        
+        # Use weighted random selection
+        return choices(available_questions, weights=weights, k=1)[0]
 
     @classmethod
     async def fetch_data(cls) -> None:

--- a/main.py
+++ b/main.py
@@ -69,12 +69,17 @@ class IUFI(commands.Bot):
         func.MUSIC_DB = func.MONGO_DB[db_name]["musics"]
 
     async def setup_hook(self) -> None:
+        func.logger.info("Startup: connecting to database...")
         # Connecting to MongoDB
         await self.connect_db()
 
+        func.logger.info("Startup: loading card pool...")
         await iufi.CardPool.fetch_data()
+        func.logger.info("Startup: processing new cards folder...")
         await iufi.CardPool.process_new_cards()
+        func.logger.info("Startup: loading quiz question pool...")
         await iufi.QuestionPool.fetch_data()
+        func.logger.info("Startup: loading music question pool...")
         await iufi.MusicPool.fetch_data()
 
         try:
@@ -85,10 +90,13 @@ class IUFI(commands.Bot):
             func.logger.error("Not able to load opus!", exc_info=e)
 
         # Load cog modules
+        func.logger.info("Startup: loading cogs...")
         for module in os.listdir(os.path.join(func.ROOT_DIR, 'cogs')):
             if module.endswith(".py"):
                 await self.load_extension(f"cogs.{module[:-3]}")
                 func.logger.info(f"Loaded {module[:-3]}")
+
+        func.logger.info("Startup: setup_hook complete, waiting for Discord READY event...")
 
     async def on_ready(self):
         func.logger.info("------------------")
@@ -108,7 +116,7 @@ class IUFI(commands.Bot):
         if isinstance(error, commands.CommandNotFound):
             return
 
-        elif isinstance(error, (commands.CommandOnCooldown, commands.MissingPermissions, commands.RangeError, commands.BadArgument)):
+        elif isinstance(error, (commands.CommandOnCooldown, commands.MissingPermissions, commands.RangeError, commands.BadArgument, commands.CheckFailure)):
             pass
 
         elif isinstance(error, (commands.MissingRequiredArgument, commands.MissingRequiredAttachment)):
@@ -155,7 +163,7 @@ intents.message_content = True
 bot = IUFI(
     command_prefix=func.settings.BOT_PREFIX,
     help_command=None,
-    chunk_guilds_at_startup=True,
+    chunk_guilds_at_startup=False,
     activity=discord.Activity(type=discord.ActivityType.listening, name=f"{func.settings.BOT_PREFIX[0]}help"),
     case_insensitive=True,
     intents=intents

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py[voice]==2.4.0
+discord.py[voice]==2.7.1
 motor==3.6.0
 python-dotenv==1.0.0
 psutil==6.0.0
@@ -12,5 +12,5 @@ psutil==6.0.0
 pillow==10.4.0
 python-Levenshtein==0.23.0
 aiohttp==3.9.5
-yt-dlp==2024.9.27
+yt-dlp[default]==2026.3.17
 ffmpeg==1.4

--- a/settings.json
+++ b/settings.json
@@ -10,11 +10,16 @@
     "GALLERY_CHANNEL": 1004494130874953769,
     "MAIN_CHAT_CHANNEL": 987354694236131418,
     "MARKET_CHANNEL": 987354574304190476,
-    "ALLOWED_CATEGORY_IDS": [987352501172989993, 1144810748158165043],
+    "ALLOWED_CATEGORY_IDS": [987352501172989993, 1144810748158165043, 1143358482494533662],
     "IGNORE_CHANNEL_IDS": [1004494130874953769, 987354694236131418],
     "GAME_CHANNEL_IDS": [1155772660979093555, 1155772719909044224, 1155772738858913792, 1155772756730859580],
-    "ADMIN_IDS": [605776164744724512, 705783356767338648],
+    "ADMIN_IDS": [605776164744724512, 705783356767338648, 1223531350972174337],
     "BUG_REPORT_CHANNEL_ID": 1384723383131967622,
+    "PERFECT_CROWN_TREASURY_CARDS": {
+        "mystic": [],
+        "legendary": [],
+        "epic": []
+    },
     "OPUS_PATH": "",
     "USER_BASE": {
         "candies": 0,
@@ -54,7 +59,21 @@
                 "progresses": {},
                 "next_update": 0
             }
-        }
+        },
+        "pvp": {
+            "wins": 0,
+            "losses": 0,
+            "total_matches": 0
+        },
+        "extra_props": {
+            "extra_card_slots": 0,
+            "slot_purchases": 0
+        },
+        "event_tokens": {
+            "perfect_crown": {},
+            "perfect_crown_count": 0
+        },
+        "event_team": null
     },
     "PITY_SETTINGS": {
         "rare": {
@@ -503,6 +522,19 @@
             }
         ]
     },
+    "PVP_SETTINGS": {
+        "power_ranges": {
+            "common": [1, 20],
+            "rare": [10, 35],
+            "epic": [25, 60],
+            "legendary": [45, 100],
+            "mystic": [70, 150],
+            "celestial": [100, 250]
+        },
+        "challenge_timeout": 300,
+        "round_delay": 4,
+        "max_reroll_attempts": 20
+    },
     "LOGGING": {
         "file": {
             "path": "./logs",
@@ -512,6 +544,68 @@
             "discord": "INFO",
             "iufi": "INFO"
         },
-        "max-history": 30
+        "max-history": 365
+    },
+    "PVP_REWARDS_ENABLED": false,
+    "GIVE_REWARD_CARD": true,
+    "MONTHLY_LEADERBOARD_ROLE": 1201455425820827708,
+    "REWARD_CARD_PROBABILITIES": {
+        "MUSIC_QUIZ": {
+            "10": {"common": 0.98, "rare": 0.02},
+            "20": {"common": 0.95, "rare": 0.045, "epic": 0.005},
+            "30": {"common": 0.90, "rare": 0.08, "epic": 0.02},
+            "40": {"common": 0.85, "rare": 0.11, "epic": 0.04},
+            "50": {"common": 0.80, "rare": 0.14, "epic": 0.06},
+            "100": {"common": 0.70, "rare": 0.20, "epic": 0.09, "legendary": 0.01},
+            "200": {"common": 0.60, "rare": 0.25, "epic": 0.13, "legendary": 0.02},
+            "300": {"common": 0.50, "rare": 0.30, "epic": 0.17, "legendary": 0.03},
+            "500": {"common": 0.40, "rare": 0.35, "epic": 0.20, "legendary": 0.05},
+            "1000": {"common": 0.30, "rare": 0.35, "epic": 0.25, "legendary": 0.10},
+            "5000": {"common": 0.20, "rare": 0.30, "epic": 0.30, "legendary": 0.15, "mystic": 0.05}
+        },
+        "NORMAL_QUIZ": {
+            "5": {"common": 0.95, "rare": 0.05},
+            "10": {"common": 0.90, "rare": 0.08, "epic": 0.02},
+            "15": {"common": 0.85, "rare": 0.11, "epic": 0.04},
+            "20": {"common": 0.75, "rare": 0.18, "epic": 0.06, "legendary": 0.01},
+            "25": {"common": 0.65, "rare": 0.23, "epic": 0.10, "legendary": 0.02},
+            "30": {"common": 0.55, "rare": 0.28, "epic": 0.14, "legendary": 0.03},
+            "40": {"common": 0.45, "rare": 0.32, "epic": 0.18, "legendary": 0.05},
+            "50": {"common": 0.35, "rare": 0.35, "epic": 0.22, "legendary": 0.08}
+        },
+        "MATCH_GAME": {
+            "1": {
+                "1": {"common": 0.98, "rare": 0.02},
+                "2": {"common": 0.95, "rare": 0.045, "epic": 0.005},
+                "3": {"common": 0.90, "rare": 0.09, "epic": 0.01}
+            },
+            "2": {
+                "1": {"common": 0.95, "rare": 0.05},
+                "2": {"common": 0.92, "rare": 0.07, "epic": 0.01},
+                "3": {"common": 0.88, "rare": 0.10, "epic": 0.02},
+                "4": {"common": 0.82, "rare": 0.14, "epic": 0.04},
+                "5": {"common": 0.75, "rare": 0.19, "epic": 0.06},
+                "6": {"common": 0.65, "rare": 0.26, "epic": 0.08, "legendary": 0.01}
+            },
+            "3": {
+                "1": {"common": 0.93, "rare": 0.07},
+                "2": {"common": 0.88, "rare": 0.10, "epic": 0.02},
+                "3": {"common": 0.82, "rare": 0.14, "epic": 0.04},
+                "4": {"common": 0.76, "rare": 0.18, "epic": 0.06},
+                "5": {"common": 0.70, "rare": 0.22, "epic": 0.07, "legendary": 0.01},
+                "6": {"common": 0.64, "rare": 0.25, "epic": 0.09, "legendary": 0.02},
+                "7": {"common": 0.58, "rare": 0.28, "epic": 0.11, "legendary": 0.03},
+                "8": {"common": 0.50, "rare": 0.32, "epic": 0.14, "legendary": 0.04},
+                "9": {"common": 0.40, "rare": 0.30, "epic": 0.20, "legendary": 0.10},
+                "10": {"common": 0.10, "rare": 0.25, "epic": 0.35, "legendary": 0.25, "mystic": 0.05}
+            }
+        },
+        "EMOJI_QUIZ": {
+            "1": {"common": 0.98, "rare": 0.02},
+            "2": {"common": 0.9, "rare": 0.09, "epic": 0.01},
+            "3": {"common": 0.75, "rare": 0.18, "epic": 0.07},
+            "4": {"common": 0.6, "rare": 0.25, "epic": 0.12, "legendary": 0.03},
+            "5": {"common": 0.45, "rare": 0.3, "epic": 0.18, "legendary": 0.07}
+        }
     }
 }

--- a/views/collection.py
+++ b/views/collection.py
@@ -86,6 +86,7 @@ class EditModal(discord.ui.Modal):
     async def on_submit(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer()
         slot, card_id = self.children[0].value, self.children[1].value
+        card = None
         if not slot.isdigit():
             return await interaction.followup.send(content=f"{interaction.user.mention} Please enter a integer in slot field.", ephemeral=True)
         
@@ -106,9 +107,10 @@ class EditModal(discord.ui.Modal):
             if card.owner_id != interaction.user.id:
                 return await interaction.followup.send("You are not the owner of this card.")
 
-        self.view.collections[self.view.sel_collection][slot - 1] = card_id
+        resolved_card_id = card.id if card else None
+        self.view.collections[self.view.sel_collection][slot - 1] = resolved_card_id
         await func.update_user(interaction.user.id, {"$set": {f"collections.{name}.{slot - 1}": card.id if card_id else None}})
-        func.logger.info(f"User {interaction.user.name}({interaction.user.id}) added card [{card.id}] to [{name}] collection in slot [{slot - 1}].")
+        func.logger.info(f"User {interaction.user.name}({interaction.user.id}) added card [{resolved_card_id}] to [{name}] collection in slot [{slot - 1}].")
         await self.view.send_msg()
 
 class CollectionDropdown(discord.ui.Select):

--- a/views/emoji_leaderboard.py
+++ b/views/emoji_leaderboard.py
@@ -1,0 +1,23 @@
+import discord
+import functions as func
+from typing import List
+
+LEADERBOARD_EMOJIS: List[str] = ["🥇", "🥈", "🥉", "🏅"]
+
+class EmojiLeaderboardView(discord.ui.View):
+    def __init__(self, author: discord.Member) -> None:
+        super().__init__(timeout=60)
+        self.author = author
+        self.message: discord.Message = None
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except:
+            pass
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user == self.author
+

--- a/views/emoji_quiz.py
+++ b/views/emoji_quiz.py
@@ -1,0 +1,375 @@
+import discord, time, json, asyncio
+import functions as func
+from random import choice
+from typing import List, Optional
+from discord.ext import commands
+
+# Emoji quiz settings
+EMOJI_QUIZ_SETTINGS = {
+    "reset_price": 30,
+    "default": {
+        "points": 0,
+        "last_update": 0,
+        "correct": 0,
+        "wrong": 0,
+        "timeout": 0,
+        "average_time": 0,
+        "highest_points": 0
+    }
+}
+
+# Load song emojis from file
+try:
+    import os
+    with open(os.path.join(func.ROOT_DIR, "data", "song_emojis.json"), encoding="utf8") as f:
+        SONG_EMOJIS: dict = json.load(f)
+except Exception:
+    SONG_EMOJIS = {}
+
+class EmojiAnswerModal(discord.ui.Modal):
+    def __init__(self, prompt: str, *args, **kwargs) -> None:
+        super().__init__(title="Enter your guess")
+        self.answer: str = ""
+        self.add_item(discord.ui.TextInput(
+            label="Your answer",
+            placeholder=prompt if len(prompt) <= 100 else prompt[:97] + "...",
+            min_length=1,
+            max_length=80,
+            style=discord.TextStyle.short
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer()
+        # store answer then stop
+        self.answer = self.children[0].value
+        self.stop()
+
+class EmojiQuizView(discord.ui.View):
+    """A multi-question emoji quiz view (5 questions).
+    Each question is a dict: {"name": str, "emojis": [str], "type": "song"|"drama"}
+    """
+    def __init__(self, author: discord.Member, questions: List[dict], timeout_per_question: float = 20):
+        super().__init__(timeout=timeout_per_question * len(questions) + (len(questions) * 5))
+        self.author = author
+        self.questions = questions  # list of question dicts
+        self._start_time = time.time()
+        self._ended_time = None
+        self.current: int = 0
+        self._results: List[bool|None] = [None] * len(self.questions)
+        self._answer_times: List[float] = []
+        self._answering_time: float = time.time()
+        self._timeout_per_question = timeout_per_question
+        self._delay_between_questions = 5
+        self.response: Optional[discord.Message] = None
+        # event used to wake the run loop when next_question advances the quiz
+        self._advance_event: asyncio.Event = asyncio.Event()
+        self._current_emoji: str = self._pick_emoji_for_current()
+
+    def _pick_emoji_for_current(self) -> str:
+        if not self.questions:
+            return ""
+        entry = self.questions[self.current]
+        ems = entry.get("emojis") if isinstance(entry, dict) else None
+        return choice(ems) if ems else ""
+
+    def build_embed(self) -> discord.Embed:
+        entry = self.questions[self.current]
+        qtype = entry.get("type", "song").lower()
+        label = "drama" if qtype == "drama" else "song"
+        embed = discord.Embed(title=f"Emoji Quiz — Question {self.current + 1}/{len(self.questions)}", color=discord.Color.random())
+        # show a discord-friendly expiry timestamp so the client updates the relative time automatically
+        expire_ts = round(self._answering_time + self._timeout_per_question)
+        embed.description = f"**Guess the IU {label}:**\n```{self._current_emoji}```\n**Ends:** <t:{expire_ts}:R>"
+        embed.set_footer(text=f"Answer the question or Skip — You'll see the next one in {self._delay_between_questions}s after each reply")
+        return embed
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user == self.author
+
+    async def next_question(self) -> None:
+        if self._ended_time:
+            return
+        if self.current + 1 >= len(self.questions):
+            return await self.end_game()
+        await asyncio.sleep(self._delay_between_questions)
+        self.current += 1
+        self._current_emoji = self._pick_emoji_for_current()
+        self._answering_time = time.time()
+        await self.response.edit(embed=self.build_embed(), view=self)
+        # notify the run loop that a new question has started
+        try:
+            self._advance_event.set()
+        except Exception:
+            pass
+
+    async def end_game(self) -> None:
+        if self._ended_time:
+            return
+        # wake the run loop if it's waiting on the advance event
+        try:
+            self._advance_event.set()
+        except Exception:
+            pass
+        self._ended_time = time.time()
+
+        summary_icons = {True: "✅", False: "❌", None: "⬛"}
+        summary = ""
+        total_points = 0
+        for idx, q in enumerate(self.questions):
+            res = self._results[idx]
+            summary += summary_icons[res]
+            if res is True:
+                total_points += 1
+
+        # update user's game_state.emoji_quiz
+        user = await func.get_user(self.author.id)
+        state = user.get("game_state", {}).get("emoji_quiz", EMOJI_QUIZ_SETTINGS["default"].copy())
+        start_time, end_time = func.get_month_unix_timestamps()
+        if not (start_time <= state.get("last_update", 0) <= end_time):
+            state = EMOJI_QUIZ_SETTINGS["default"].copy()
+
+        old_highest = state.get("highest_points", 0)
+        state["points"] = max(0, state.get("points", 0) + total_points)
+        if state["points"] > old_highest:
+            state["highest_points"] = state["points"]
+
+        state["last_update"] = time.time()
+        state["correct"] += self._results.count(True)
+        state["wrong"] += self._results.count(False)
+        state["timeout"] += self._results.count(None)
+
+        # average time
+        answered_count = len(self._answer_times)
+        avg_time = round(sum(self._answer_times) / answered_count, 1) if answered_count else 0
+        # roll existing average into stored average
+        total_played = state["correct"] + state["wrong"] + state["timeout"]
+        if state.get("average_time"):
+            state["average_time"] = round(((state["average_time"] * (total_played - 1)) + avg_time) / total_played, 1) if total_played > 0 else avg_time
+        else:
+            state["average_time"] = avg_time
+
+        await func.update_user(self.author.id, {"$set": {"game_state.emoji_quiz": state}})
+
+        embed = discord.Embed(title="Emoji Quiz Result", color=discord.Color.random())
+        embed.description = f"```{summary}```\n**Total points:** {total_points}\n**Correct:** {self._results.count(True)} | **Wrong:** {self._results.count(False)} | **Timeout:** {self._results.count(None)}\n**Avg Answer Time:** {func.convert_seconds(avg_time)}"
+
+        try:
+            await self.response.edit(content=None, embed=embed, view=None)
+        except:
+            pass
+
+        # Log quiz end
+        try:
+            func.logger.info(f"Emoji quiz ended for user {self.author.name}({self.author.id}) - points={total_points}, correct={self._results.count(True)}, wrong={self._results.count(False)}, timeout={self._results.count(None)}, avg_time={avg_time}s")
+        except Exception:
+            pass
+
+        # If the player scored >0 points, present a card reward view based on their points.
+        # Points are already between 0 and 5 (max questions = 5). If 0, no rewards.
+        if total_points and total_points > 0:
+            try:
+                # Import the RewardCardView from the local views package
+                from .reward_card import RewardCardView
+
+                points = min(5, int(total_points))
+                # Get probabilities from settings
+                probs_config = func.settings.REWARD_CARD_PROBABILITIES or {}
+                probs_config = probs_config.get("EMOJI_QUIZ", {})
+                probs = probs_config.get(str(points), probs_config.get("5", {}))
+
+                # Create the reward view (we won't call its send method; we'll roll a card and post on the same channel)
+                reward_view = RewardCardView(None, self.author, probs, initial_cost=10, cost_currency_field="candies", timeout=120)
+
+                # Roll initial card for the view so build_embed has a card to show
+                await reward_view._roll_card()
+
+                # Build the embed & attempt to attach the card image
+                reward_embed = reward_view.build_embed()
+                file = None
+                if reward_view.current_card:
+                    try:
+                        img_bytes = await reward_view.current_card.image_bytes()
+                        filename = f"{reward_view.current_card.id}.webp"
+                        file = discord.File(img_bytes, filename=filename)
+                        reward_embed.set_image(url=f"attachment://{filename}")
+                    except Exception:
+                        file = None
+
+                # Post the reward message in the same channel as the quiz response and attach the view
+                reward_content = f"**{self.author.mention} This reward ends <t:{reward_view.expires_at}:R>**\n🎁 Card reward for scoring {total_points} point{'s' if total_points != 1 else ''}!"
+                reward_msg = await self.response.channel.send(
+                    content=reward_content,
+                    embed=reward_embed,
+                    file=file,
+                    view=reward_view
+                )
+                reward_view.message = reward_msg
+            except Exception:
+                # Fail silently (don't block quiz end) but log if logger available
+                try:
+                    func.logger.exception("Failed to present emoji quiz reward view")
+                except:
+                    pass
+        self.stop()
+
+    @discord.ui.button(label="Answer", style=discord.ButtonStyle.green)
+    async def answer(self, interaction: discord.Interaction, button: discord.ui.Button):
+        # Capture the question index and answering time at the moment the button is pressed.
+        question_idx = self.current
+        answering_time_at_press = self._answering_time
+
+        # If this question is already answered (fast check at press time), reject immediately.
+        if self._results[question_idx] is not None:
+            return await interaction.response.send_message("You already answered this question.", ephemeral=True)
+
+        # Show the modal using the emoji snapshot for this question
+        modal = EmojiAnswerModal(self._current_emoji)
+        await interaction.response.send_modal(modal)
+        await modal.wait()
+
+        # If the quiz ended while waiting, ignore submission
+        if self._ended_time:
+            return
+
+        # If the question index has changed or the time for that question has expired,
+        # do not accept the answer (it arrived too late).
+        time_since_press = time.time() - answering_time_at_press
+        if question_idx != self.current or time_since_press > self._timeout_per_question:
+            # Inform the user their answer arrived too late and do not mark as answered.
+            try:
+                await interaction.followup.send("Too late — the question has already moved on or timed out, your answer wasn't counted.", ephemeral=True)
+            except Exception:
+                pass
+            return
+
+        # Record time and evaluate answer for the captured question index
+        used_time = time.time() - answering_time_at_press
+        self._answer_times.append(used_time)
+
+        user_answer = func.clean_text(modal.answer, convert_to_lower=True)
+        correct = func.clean_text(self.questions[question_idx].get("name", ""), convert_to_lower=True)
+        is_correct = False
+        if user_answer:
+            # Use similarity functions for better fuzzy matching
+            jac_sim = func.jac_similarity(user_answer, correct)
+            lev_sim = func.lev_similarity(user_answer, correct)
+
+            # Consider correct if either similarity is high (>= 0.8) or exact/substring match
+            if jac_sim >= 0.8 or lev_sim >= 0.8 or user_answer == correct:
+                is_correct = True
+
+        # Mark the result for the original question index
+        self._results[question_idx] = is_correct
+
+        msg = f"<:IUgiggles:1144937008037384204> {'Correct' if is_correct else 'Incorrect'}. "
+        if is_correct:
+            msg += f"You answered in `{func.convert_seconds(used_time)}`"
+        else:
+            msg += f"The correct answer: `{self.questions[question_idx].get('name')}`"
+
+        await interaction.followup.send(msg, ephemeral=True)
+        await self.next_question()
+
+    @discord.ui.button(label="Skip", style=discord.ButtonStyle.gray)
+    async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if self._results[self.current] is not None:
+            return await interaction.response.send_message("You already answered this question.", ephemeral=True)
+        self._results[self.current] = False
+        self._answer_times.append(self._timeout_per_question)
+        await interaction.response.send_message(f"Skipped. The correct answer was `{self.questions[self.current].get('name')}`.", ephemeral=True)
+        await self.next_question()
+
+    async def on_timeout(self) -> None:
+        # mark unanswered questions as timeout
+        for idx, res in enumerate(self._results):
+            if res is None:
+                self._results[idx] = None
+        try:
+            if self.response:
+                await self.response.edit(content=f"Emoji quiz expired <t:{round(time.time())}:R>.", view=None)
+        except:
+            pass
+        self.stop()
+
+    @property
+    def total_time(self) -> float:
+        return len(self.questions) * (self._timeout_per_question + self._delay_between_questions)
+
+    async def run(self) -> None:
+        """Run the per-question timer loop until the quiz ends."""
+        # ensure answering_time is set
+        self._answering_time = self._answering_time or time.time()
+        while not self._ended_time:
+            # compute remaining time for the current question
+            remaining = (self._answering_time + self._timeout_per_question) - time.time()
+            if remaining > 0:
+                try:
+                    # wait until either the question advances (event set) or timeout expires
+                    await asyncio.wait_for(self._advance_event.wait(), timeout=remaining)
+                    # if event set, clear and continue to monitor the new question
+                    self._advance_event.clear()
+                    continue
+                except asyncio.TimeoutError:
+                    # timeout expired for this question
+                    pass
+
+            # If current question still unanswered, treat as timeout
+            if self._results[self.current] is None:
+                # record timeout
+                self._answer_times.append(self._timeout_per_question)
+                # send ephemeral-ish notification (channel message deleted shortly after)
+                try:
+                    await self.response.channel.send(f"Time's up for question {self.current + 1}! The correct answer was `{self.questions[self.current].get('name')}`.", delete_after=self._delay_between_questions)
+                except:
+                    pass
+
+                # move to next question (this function will call end_game when done)
+                await self.next_question()
+            else:
+                # already answered; wait briefly and loop
+                await asyncio.sleep(0.1)
+
+        # ensure end_game called
+        if not self._ended_time:
+            await self.end_game()
+
+class EmojiResetAttemptView(discord.ui.View):
+    def __init__(self, ctx: commands.Context, user_data: dict, price: int, timeout: float = 20):
+        super().__init__(timeout=timeout)
+
+        self.ctx: commands.Context = ctx
+        self.data: dict = user_data
+        self.price: int = price
+        self.response: discord.Message = None
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.TextStyle = discord.ButtonStyle.grey
+            child.disabled = True
+        try:
+            await self.response.edit(view=self)
+        except:
+            pass
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user == self.ctx.author
+
+    @discord.ui.button(label="Buy", emoji="🛍️", style=discord.ButtonStyle.green)
+    async def buy(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        if self.data.get("candies") < self.price:
+            await interaction.response.send_message("You do not have enough candies to initiate the reset!", ephemeral=True)
+            return await self.on_timeout()
+
+        await func.update_user(self.ctx.author.id, {
+            "$set": {"cooldown.quiz_game": 0},
+            "$inc": {"candies": -self.price}
+        })
+
+        if self.response:
+            try:
+                await self.response.delete()
+            except:
+                pass
+
+        # invoke emojiquiz command (not the normal quiz)
+        await self.ctx.invoke(self.ctx.bot.get_command("emojiquiz"))

--- a/views/help.py
+++ b/views/help.py
@@ -16,6 +16,7 @@ class HelpView(discord.ui.View):
         self.add_item(discord.ui.Button(label='Github', emoji=':github:1098265017268322406', url='https://github.com/ChocoMeow/IUFI'))
         self.add_item(discord.ui.Button(label='Beginner Guide', emoji='📗', url='https://docs.google.com/document/d/1VAD20wZQ56S_wDeMJlwIKn_jImIPuxh2lgy1fn17z0c/edit'))
         self.add_item(discord.ui.Button(label='Donate', emoji='🎁', url='https://ko-fi.com/chocoo'))
+        self.add_item(discord.ui.Button(label='Card Archive', emoji='🗂️', url='https://d1w5gpixxno4sl.cloudfront.net'))
         
     async def on_error(self, error, item, interaction) -> None:
         return

--- a/views/matchgame.py
+++ b/views/matchgame.py
@@ -8,7 +8,7 @@ from iufi import (
     gen_cards_view
 )
 
-from random import shuffle, choice
+from random import shuffle
 from typing import Any
 from collections import Counter
 
@@ -135,38 +135,15 @@ class MatchGame(discord.ui.View):
         for child in self.children:
             child.disabled = True
 
-        embed = discord.Embed(title="Game Ended (Rewards)", color=discord.Color.random())
+        embed = discord.Embed(title="Game Ended", color=discord.Color.random())
         matched_raw = self.matched()
-        final_rewards: dict[str, int] = {}
-        
-        rewards = f"{'Pairs':>9}{'Rewards':>9}\n"
-        for matched, reward in self._data.get("rewards").items():
-            if isinstance(reward[0], list):
-                reward = choice(reward)
-            
-            if is_matched := (int(matched) <= matched_raw):
-                if reward[0] not in final_rewards:
-                    final_rewards[reward[0]] = 0
-                final_rewards[reward[0]] += reward[1]
+        embed.description = (
+            f"```{'🕔 Time Used:':<15} {func.convert_seconds(self.used_time)}\n"
+            f"{'🃏 Matched:':<15} {matched_raw}```\n"
+            "Reward type: claimable card drop (probability-based)."
+        )
 
-            reward_name, amount = reward
-            reward_name = reward_name.split(".")
-
-            rewards += ("✅" if is_matched else "⬛") + f"  {matched:<3}"
-            if reward_name[0] == "candies":
-                rewards += f"    {'🍬 Candies':<18} x{amount}\n"
-            
-            elif reward_name[0] == "exp":
-                rewards += f"    {'⚔️ Exp':<19} x{amount}\n"
-
-            else:
-                reward_name = reward_name[1].split("_")
-                potion_data = func.settings.POTIONS_BASE.get(reward_name[0])
-                rewards += f"    {potion_data.get('emoji') + ' ' + reward_name[0].title() + ' ' + reward_name[1].upper() + ' Potion':<18} x{amount}\n"
-            
-        embed.description = f"```{'🕔 Time Used:':<15} {func.convert_seconds(self.used_time)}\n{'🃏 Matched:':<15} {matched_raw}```\n```{rewards}```"
-
-        update_data = {"$inc": final_rewards}
+        update_data: dict[str, Any] = {}
         user = await func.get_user(self.author.id)
 
         best_state = user.get("game_state", {}).get("match_game", {}).get(self._level, {
@@ -198,6 +175,54 @@ class MatchGame(discord.ui.View):
         )
 
         await self.response.channel.send(content=f"<@{self.author.id}>", embed=embed)
+
+        # Present probability-based reward card for match game performance.
+        if matched_raw > 0:
+            try:
+                from .reward_card import RewardCardView
+
+                probs_config = func.settings.REWARD_CARD_PROBABILITIES or {}
+                level_probs = probs_config.get("MATCH_GAME", {}).get(str(self._level), {})
+
+                probs = level_probs.get(str(matched_raw))
+                if not probs and level_probs:
+                    # Fallback to the highest configured threshold <= matched pairs.
+                    eligible = [(int(k), v) for k, v in level_probs.items() if str(k).isdigit() and int(k) <= matched_raw]
+                    if eligible:
+                        probs = max(eligible, key=lambda item: item[0])[1]
+
+                if probs:
+                    reward_view = RewardCardView(None, self.author, probs, initial_cost=10, cost_currency_field="candies", timeout=120)
+                    await reward_view._roll_card()
+
+                    reward_embed = reward_view.build_embed()
+                    file = None
+                    if reward_view.current_card:
+                        try:
+                            img_bytes = await reward_view.current_card.image_bytes()
+                            filename = f"{reward_view.current_card.id}.webp"
+                            file = discord.File(img_bytes, filename=filename)
+                            reward_embed.set_image(url=f"attachment://{filename}")
+                        except Exception:
+                            file = None
+
+                    reward_content = (
+                        f"**{self.author.mention} This reward ends <t:{reward_view.expires_at}:R>**\n"
+                        f"🎁 Card reward for matching {matched_raw} pair{'s' if matched_raw != 1 else ''} on level {self._level}!"
+                    )
+                    reward_msg = await self.response.channel.send(
+                        content=reward_content,
+                        embed=reward_embed,
+                        file=file,
+                        view=reward_view
+                    )
+                    reward_view.message = reward_msg
+            except Exception:
+                try:
+                    func.logger.exception("Failed to present match game reward card view")
+                except Exception:
+                    pass
+
         self.stop()
         
     async def build(self) -> tuple[discord.Embed, discord.File]:

--- a/views/profile_status.py
+++ b/views/profile_status.py
@@ -1,0 +1,242 @@
+import discord
+import iufi
+import functions as func
+
+from discord.ext import commands
+from pydantic import BaseModel
+from typing import Optional, List, Dict
+
+class QuizGame(BaseModel):
+    points: float = 0
+    correct: int = 0
+    wrong: int = 0
+    timeout: int = 0
+    average_time: float = 0
+    highest_points: float = 0
+    last_update: float = 0
+
+    @property
+    def accuracy(self) -> float:
+        return round((self.correct / self.total_questions * 100), 1) if self.total_questions > 0 else 0
+
+    @property
+    def total_questions(self) -> int:
+        return self.correct + self.wrong + self.timeout
+    
+    @property
+    def total_wrong(self) -> int:
+        return self.wrong + self.timeout
+    
+    @property
+    def rank_name(self) -> str:
+        return iufi.QuestionPool.get_rank(self.points)[0].title()
+
+    @property
+    def rank_emoji(self) -> str:
+        return iufi.QuestionPool.get_rank(self.points)[1]
+    
+class MatchGameLevel(BaseModel):
+    click_left: int = 0
+    matched: int = 0
+    last_update: float
+    finished_time: float = 0
+    monthly_click_left: int = 0
+    monthly_matched: int = 0
+    monthly_finished_time: float = 0
+
+class MusicGame(BaseModel):
+    points: int = 0
+    last_update: float = 0
+    monthly_points: int = 0
+
+class EmojiQuiz(BaseModel):
+    points: float = 0
+    correct: int = 0
+    wrong: int = 0
+    timeout: int = 0
+    average_time: float = 0
+    highest_points: float = 0
+    last_update: float = 0
+
+    @property
+    def total_questions(self) -> int:
+        return self.correct + self.wrong + self.timeout
+
+    @property
+    def total_wrong(self) -> int:
+        return self.wrong + self.timeout
+    
+    @property
+    def accuracy(self) -> float:
+        return round((self.correct / self.total_questions * 100), 1) if self.total_questions > 0 else 0
+
+class MVGuess(BaseModel):
+    monthly_points: int = 0
+    last_update: float = 0
+
+class GameStates(BaseModel):
+    quiz_game: Optional[QuizGame] = None
+    match_game: Optional[Dict[str, MatchGameLevel]] = None
+    music_game: Optional[MusicGame] = None
+    emoji_quiz: Optional[EmojiQuiz] = None
+    mv_guess: Optional[MVGuess] = None
+
+class PVPStats(BaseModel):
+    wins: int = 0
+    losses: int = 0
+    total_matches: int = 0
+
+    @property
+    def total_matches(self) -> int:
+        return self.wins + self.losses
+    
+    @property
+    def win_rate(self) -> float:
+        return round((self.wins / self.total_matches) * 100, 1) if self.total_matches > 0 else 0
+    
+class ProfileStatsView(discord.ui.View):
+    def __init__(self, ctx: commands.Context, member: discord.Member, daily_rows: List[str]):
+        super().__init__(timeout=180.0)  # 3 minutes timeout
+        self.ctx = ctx
+        self.member = member
+        self.daily_rows = daily_rows
+        self.message: Optional[discord.Message] = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Only allow the command invoker and the profile owner to use buttons"""
+        if interaction.user.id not in (self.ctx.author.id, self.member.id):
+            await interaction.response.send_message(
+                "❌ You cannot use these buttons. Only the command invoker or profile owner can interact.",
+                ephemeral=True
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        """Disable buttons when view times out"""
+        if self.message:
+            for item in self.children:
+                if isinstance(item, discord.ui.Button):
+                    item.disabled = True
+            try:
+                await self.message.edit(view=self)
+            except:
+                pass  # Message might be deleted
+
+    @discord.ui.button(label="Game Stats", style=discord.ButtonStyle.primary, emoji="📊")
+    async def show_stats(self, interaction: discord.Interaction, button: discord.ui.Button):
+        """Sends the full game stats when the button is clicked."""
+        # Re-fetch user data
+        user = await func.get_user(self.member.id)
+        raw_game_state = user.get("game_state") or {}
+        game_state = GameStates(**raw_game_state)
+
+        pvp_raw = user.get("pvp")
+        pvp_stats = PVPStats(**pvp_raw) if pvp_raw else None
+
+        embed = discord.Embed(
+            title=f"🎮 {self.member.display_name}'s Detailed Stats",
+            color=discord.Color.from_rgb(138, 43, 226)
+        )
+        embed.set_thumbnail(url=self.member.display_avatar.url)
+
+        # Quiz Game field (inline)
+        if (quiz := game_state.quiz_game) and quiz.points > 0:
+            quiz_value = (
+                "```yaml\n"
+                f"Rank:         {quiz.rank_name}\n"
+                f"Points:       {quiz.points:,}\n"
+                f"Accuracy:     {quiz.accuracy}%\n"
+                f"Correct:      {quiz.correct:,}\n"
+                f"Wrong:        {quiz.total_wrong:,}\n"
+                f"Avg Time:     {func.convert_seconds(quiz.average_time)}\n"
+                "```"
+            )
+        else:
+            quiz_value = "```No quiz stats available.```"
+
+        embed.add_field(name=func.framed_title("Quiz Game"), value=quiz_value, inline=False)
+
+        # Card Match field (inline)
+        if match_game := game_state.match_game:
+            lines = []
+            # iterate the configured levels (ensure stable iteration by casting to list)
+            for level_key in list(func.settings.MATCH_GAME_SETTINGS.keys()):
+                mg = match_game.get(str(level_key))
+                prefix = self.daily_rows[int(level_key) - 4]
+                lines.append(f"{prefix} Lvl {level_key}: " + f"{mg.matched:>2} cards | {func.convert_seconds(mg.finished_time)}" if mg else "Not attempted")
+            match_value = "```\n" + "\n".join(lines) + "\n```"
+        else:
+            match_value = "```No card match stats available.```"
+
+        embed.add_field(name=func.framed_title("Card Match"), value=match_value, inline=False)
+
+        # Music Game field (inline)
+        if (quiz := game_state.music_game) and quiz.points > 0:
+            music_value = (
+                "```yaml\n"
+                f"Points:       {quiz.points:,}\n"
+                f"Monthly Pts:  {quiz.monthly_points:,}\n"
+                "```"
+            )
+        else:
+            music_value = "```No music game stats available.```"
+        
+        embed.add_field(name=func.framed_title("Music Game"), value=music_value, inline=False)
+        
+        # Emoji Quiz field (inline)
+        if (quiz := game_state.emoji_quiz) and quiz.points > 0:
+            emoji_value = (
+                "```yaml\n"
+                f"Points:       {quiz.points:,}\n"
+                f"Accuracy:     {quiz.accuracy}%\n"
+                f"Correct:      {quiz.correct:,}\n"
+                f"Wrong:        {quiz.total_wrong:,}\n"
+                f"Avg Time:     {func.convert_seconds(quiz.average_time)}\n"
+                "```"
+            )
+        else:
+            emoji_value = "```No emoji quiz stats available.```"
+
+        embed.add_field(name=func.framed_title("Emoji Quiz"), value=emoji_value, inline=False)
+
+        # PvP Game field (inline)
+        if pvp_stats:
+            wins = getattr(pvp_stats, "wins", 0)
+            losses = getattr(pvp_stats, "losses", 0)
+            total = getattr(pvp_stats, "total_matches", 0)
+            win_rate = getattr(pvp_stats, "win_rate", 0)
+
+            wl_ratio = f"{round(wins / losses, 2)}" if losses > 0 else "∞"
+
+            pvp_bar = ""
+            if total > 0:
+                win_blocks = int((wins / total) * 10)
+                win_blocks = max(0, min(10, win_blocks))
+                loss_blocks = 10 - win_blocks
+                pvp_bar = f"{'🟩' * win_blocks}{'🟥' * loss_blocks}"
+
+            pvp_value = (
+                "```yaml\n"
+                f"Total Matches:  {total}\n"
+                f"Wins:           {wins}\n"
+                f"Losses:         {losses}\n"
+                f"Win Rate:       {win_rate}%\n"
+                f"W/L Ratio:      {wl_ratio}\n"
+                "```"
+            )
+            if pvp_bar:
+                pvp_value += f"{pvp_bar} `{win_rate}%`\n"
+        else:
+            pvp_value = "```No PVP stats available.```"
+
+        embed.add_field(name=func.framed_title("PVP Stats"), value=pvp_value, inline=False)
+        embed.set_footer(text="Keep playing to improve your stats! 🌟")
+
+        await interaction.response.send_message(embed=embed)
+
+    @discord.ui.button(label="Collections", style=discord.ButtonStyle.primary, emoji="💕")
+    async def show_collections(self, interaction: discord.Interaction[commands.Bot], button: discord.ui.Button):
+        """Shows the member's collections using the existing CollectionView."""
+        await interaction.response.defer()
+        await interaction.client.get_command("f")(self.ctx)

--- a/views/pvp.py
+++ b/views/pvp.py
@@ -1,0 +1,888 @@
+import discord
+import asyncio
+import time
+import random
+from typing import Optional, Dict, List
+from PIL import Image, ImageDraw, ImageFont
+from io import BytesIO
+
+import functions as func
+from iufi import CardPool, Card
+from discord.ext import commands
+
+# Prefer a bundled font inside the repo (fonts/DejaVuSans.ttf). If it's missing, try common system fonts.
+FONT_CANDIDATES = [
+    'fonts/DejaVuSans.ttf',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+    '/Library/Fonts/Arial.ttf',
+    '/System/Library/Fonts/Supplemental/Arial.ttf',
+]
+
+def load_truetype(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Load a TrueType font from the bundled fonts/ folder first, then fall back to common system fonts.
+
+    This prefers a local, committed TTF so rendering is consistent across hosts. If no TTF is found,
+    it falls back to PIL's default bitmap font (less ideal).
+    """
+    for candidate in FONT_CANDIDATES:
+        try:
+            f = ImageFont.truetype(candidate, size)
+            # Log which font path was used for easier debugging
+            return f
+        except Exception:
+            continue
+
+    try:
+        func.logger.warning("No TrueType font found in repo or system paths; falling back to bitmap font.")
+    except Exception:
+        pass
+    return ImageFont.load_default()
+
+
+# PvP implementation: Challenge -> both players submit 3-card teams (via modal) -> best-of-3 rounds
+# Configurable via func.settings.PVP_SETTINGS if present, otherwise fallback defaults.
+
+
+def get_pvp_settings():
+    defaults = {
+        "power_ranges": {
+            "common": [1, 20],
+            "rare": [10, 35],
+            "epic": [25, 60],
+            "legendary": [45, 100],
+            "mystic": [70, 150],
+            "celestial": [100, 250]
+        },
+        "challenge_timeout": 300,
+        "round_delay": 4,
+        "post_round_delay": 3,
+        "max_reroll_attempts": 20
+    }
+    # Prefer the repo settings.PVP_SETTINGS if available, otherwise fall back to defaults
+    return func.settings.PVP_SETTINGS or defaults
+
+
+# RPS faction helpers
+# Group rarities into three factions for a rock-paper-scissors style bonus:
+#  A (Low): Common, Rare
+#  B (Mid): Epic, Legendary
+#  C (High): Mystic, Celestial
+# A beats B, B beats C, C beats A -> winner gets +25% power bonus
+RPS_FACTIONS = {
+    'A': ('common', 'rare'),
+    'B': ('epic', 'legendary'),
+    'C': ('mystic', 'celestial')
+}
+
+
+def faction_for_tier(tier: str) -> Optional[str]:
+    if not tier:
+        return None
+    t = tier.lower()
+    for f, tiers in RPS_FACTIONS.items():
+        if t in tiers:
+            return f
+    return None
+
+
+def rps_bonus_pct(attacker_tier: str, defender_tier: str) -> float:
+    """Return the RPS bonus percentage (0.25 for +25% when attacker beats defender, else 0.0)."""
+    a = faction_for_tier(attacker_tier)
+    b = faction_for_tier(defender_tier)
+    if a is None or b is None:
+        return 0.0
+    # A beats B, B beats C, C beats A
+    if (a == 'A' and b == 'B') or (a == 'B' and b == 'C') or (a == 'C' and b == 'A'):
+        return 0.25
+    return 0.0
+
+
+# Small helper to produce a human-friendly label for a member when mentions aren't desired
+def player_label(member: discord.Member | str) -> str:
+    try:
+        if isinstance(member, discord.Member):
+            return getattr(member, 'display_name', str(member))
+    except Exception:
+        pass
+    return str(member)
+
+
+async def compose_vs_image(a_card: Card, b_card: Card, *, highlight: Optional[str] = None, size_rate: float = 0.28) -> BytesIO:
+    """Create a stitched image: left card vs right card. If highlight is 'left' or 'right', draw a border around the winner."""
+    # Load images (may be lists for GIFs)
+    a_img = await a_card.image(size_rate=size_rate)
+    b_img = await b_card.image(size_rate=size_rate)
+    if isinstance(a_img, list):
+        a_img = a_img[0]
+    if isinstance(b_img, list):
+        b_img = b_img[0]
+
+    if a_img.mode != 'RGBA':
+        a_img = a_img.convert('RGBA')
+    if b_img.mode != 'RGBA':
+        b_img = b_img.convert('RGBA')
+
+    padding = 12
+    middle_w = max(int(a_img.width * 0.35), 80)
+    out_w = a_img.width + b_img.width + middle_w + padding * 4
+    out_h = max(a_img.height, b_img.height) + padding * 2
+
+    out = Image.new('RGBA', (out_w, out_h), (0, 0, 0, 0))
+    left_x = padding
+    left_y = (out_h - a_img.height) // 2
+    right_x = left_x + a_img.width + middle_w + padding * 2
+    right_y = (out_h - b_img.height) // 2
+
+    out.paste(a_img, (left_x, left_y), a_img)
+    out.paste(b_img, (right_x, right_y), b_img)
+
+    draw = ImageDraw.Draw(out)
+
+    # draw highlight border & a bottom ribbon over only the winning card if needed
+    if highlight in ('left', 'right'):
+        # determine box for winner (card coordinates)
+        if highlight == 'left':
+            bx, by, bw, bh = left_x, left_y, a_img.width, a_img.height
+        else:
+            bx, by, bw, bh = right_x, right_y, b_img.width, b_img.height
+
+        # soft glowing border around the winner card
+        glow_color = (34, 197, 94, 255)  # green-ish
+        for i in range(6, 0, -2):
+            rect = [bx - i, by - i, bx + bw + i, by + bh + i]
+            draw.rounded_rectangle(rect, radius=12 + i, outline=(glow_color[0], glow_color[1], glow_color[2], int(30 + (i * 30 / 6))))
+
+        # draw a ribbon only across the bottom of the winner card (with slight horizontal padding)
+        ribbon_h = max(int(bh * 0.14), 20)
+        # position ribbon so it sits at the bottom of the card; allow small horizontal extension
+        hor_pad = max(int(bw * 0.06), 8)
+        rx = max(0, bx - hor_pad)
+        rw = min(out_w - rx, bw + hor_pad * 2)
+        ry = by + bh - ribbon_h
+        ribbon_color = (16, 185, 129, 255)  # green
+
+        # rounded ribbon rectangle
+        radius = max(6, int(ribbon_h * 0.25))
+        draw.rounded_rectangle([rx, ry, rx + rw, ry + ribbon_h], radius=radius, fill=ribbon_color)
+
+        # draw WINNER text centered in that ribbon using high-res rendering to avoid pixelation
+        text = "WINNER"
+        # target font size (relative to ribbon height)
+        base_font_size = max(14, int(ribbon_h * 0.6))
+        scale = 4  # render at 4x and downscale for smooth edges
+        try:
+            font_hi = load_truetype(base_font_size * scale)
+        except Exception:
+            font_hi = ImageFont.load_default()
+
+        # create temporary high-res canvas for text
+        tmp_w = max(1, int(rw * scale))
+        tmp_h = max(1, int(ribbon_h * scale))
+        tmp = Image.new('RGBA', (tmp_w, tmp_h), (0, 0, 0, 0))
+        td = ImageDraw.Draw(tmp)
+
+        # measure text in high-res
+        tb = td.textbbox((0, 0), text, font=font_hi)
+        text_w_hi = tb[2] - tb[0]
+        text_h_hi = tb[3] - tb[1]
+        tx_hi = (tmp_w - text_w_hi) // 2
+        ty_hi = (tmp_h - text_h_hi) // 2
+
+        # draw shadow slightly offset (high-res) then white text
+        shadow_color = (0, 0, 0, 200)
+        td.text((tx_hi - int(2 * scale), ty_hi - int(2 * scale)), text, font=font_hi, fill=shadow_color)
+        td.text((tx_hi + int(2 * scale), ty_hi + int(2 * scale)), text, font=font_hi, fill=shadow_color)
+        td.text((tx_hi, ty_hi), text, font=font_hi, fill=(255, 255, 255, 255))
+
+        # downscale to ribbon size using the best available resampling filter and paste with alpha
+        resample_filter = getattr(Image, 'LANCZOS', None)
+        if resample_filter is None:
+            resampling = getattr(Image, 'Resampling', None)
+            if resampling and hasattr(resampling, 'LANCZOS'):
+                resample_filter = resampling.LANCZOS
+            else:
+                # try BICUBIC then fallback to NEAREST
+                resample_filter = getattr(Image, 'BICUBIC', None)
+                if resample_filter is None and resampling and hasattr(resampling, 'BICUBIC'):
+                    resample_filter = resampling.BICUBIC
+                if resample_filter is None:
+                    resample_filter = getattr(Image, 'NEAREST', 0)
+
+        small = tmp.resize((int(tmp_w / scale), int(tmp_h / scale)), resample=resample_filter)
+        out.paste(small, (int(rx), int(ry)), small)
+
+    # Draw VS in middle lightly for the preview too
+    # Prefer bundled TrueType via load_truetype; fallback to bitmap font if unavailable
+    try:
+        font = load_truetype(max(28, int(out_h * 0.12)))
+    except Exception:
+        font = ImageFont.load_default()
+    vs_text = "VS"
+    vb = draw.textbbox((0, 0), vs_text, font=font)
+    v_w = vb[2] - vb[0]
+    v_h = vb[3] - vb[1]
+    vx = left_x + a_img.width + (middle_w // 2) + padding - (v_w // 2)
+    vy = (out_h - v_h) // 2
+    draw.text((vx - 1, vy - 1), vs_text, font=font, fill=(0, 0, 0, 255))
+    draw.text((vx + 1, vy + 1), vs_text, font=font, fill=(0, 0, 0, 255))
+    draw.text((vx, vy), vs_text, font=font, fill=(255, 255, 255, 255))
+
+    bytes_io = BytesIO()
+    out.save(bytes_io, format='WEBP')
+    bytes_io.seek(0)
+    return bytes_io
+
+
+async def compose_three_image(cards: list[Card], *, size_rate: float = 0.28, use_cover: bool = False) -> BytesIO:
+    """Stitch three images horizontally and return a BytesIO WEBP file.
+
+    If use_cover is True, use images from the cover folder (level1.webp..level3.webp)
+    rather than the actual card images. This is used to hide the real cards during reward selection.
+    """
+    import os
+
+    imgs = []
+    if use_cover:
+        # preferred cover filenames in order
+        cover_dir = os.path.join(func.ROOT_DIR, 'cover')
+        preferred = ['level1.webp', 'level2.webp', 'level3.webp']
+        available_pref = [os.path.join(cover_dir, n) for n in preferred if os.path.exists(os.path.join(cover_dir, n))]
+
+        if available_pref:
+            # Use the preferred set (or subset) and shuffle to randomize positions
+            covers = available_pref[:]
+            random.shuffle(covers)
+            # If fewer covers than cards, repeat the list
+            while len(covers) < len(cards):
+                covers.extend(available_pref)
+            covers = covers[:len(cards)]
+        else:
+            # fallback: any webp in the cover folder
+            cover_paths = [os.path.join(func.ROOT_DIR, 'cover', f) for f in os.listdir(os.path.join(func.ROOT_DIR, 'cover')) if f.lower().endswith('.webp')]
+            if not cover_paths:
+                raise RuntimeError('No cover images found in cover/ folder')
+            covers = random.sample(cover_paths, k=min(len(cover_paths), len(cards)))
+            while len(covers) < len(cards):
+                covers.append(random.choice(cover_paths))
+
+        # Load the cover images in the order of covers list
+        for path in covers:
+            try:
+                with Image.open(path) as im:
+                    img = im.convert('RGBA')
+                    target_size = (int(img.width * size_rate), int(img.height * size_rate))
+                    img = img.resize(target_size, Image.LANCZOS)
+                    imgs.append(img)
+            except Exception:
+                continue
+    else:
+        for c in cards:
+            try:
+                img = await c.image(size_rate=size_rate)
+                if isinstance(img, list):
+                    img = img[0]
+                if img.mode != 'RGBA':
+                    img = img.convert('RGBA')
+                imgs.append(img)
+            except Exception:
+                # fallback to the first card's image if individual fails
+                try:
+                    tmp = await CardPool.get_card(cards[0].id).image(size_rate=size_rate) if cards else None
+                    if tmp:
+                        if isinstance(tmp, list):
+                            tmp = tmp[0]
+                        imgs.append(tmp)
+                except Exception:
+                    continue
+
+    if not imgs:
+        raise RuntimeError("No images available to compose three-image")
+
+    # If fewer than requested (shouldn't normally happen), duplicate last to fill the row
+    while len(imgs) < len(cards):
+        imgs.append(imgs[-1])
+
+    padding = 10
+    widths = [im.width for im in imgs]
+    heights = [im.height for im in imgs]
+    total_w = sum(widths) + padding * (len(imgs) - 1)
+    max_h = max(heights)
+
+    out = Image.new('RGBA', (total_w, max_h), (0, 0, 0, 0))
+    x = 0
+    for im in imgs:
+        y = (max_h - im.height) // 2
+        out.paste(im, (x, y), im)
+        x += im.width + padding
+
+    bio = BytesIO()
+    out.save(bio, format='WEBP')
+    bio.seek(0)
+    return bio
+
+
+class PvPMatch:
+    def __init__(self, ctx: Optional[commands.Context], challenger: discord.Member, opponent: discord.Member, settings: dict):
+        self.ctx = ctx
+        self.challenger = challenger
+        self.opponent = opponent
+        self.started_at = time.time()
+        self.settings = settings
+        self.teams: Dict[int, List[Card]] = {}
+        self.wins: Dict[int, int] = {challenger.id: 0, opponent.id: 0}
+        self.message: Optional[discord.Message] = None
+        self._lock = asyncio.Lock()
+
+    def is_ready(self) -> bool:
+        return (self.challenger.id in self.teams) and (self.opponent.id in self.teams)
+
+    async def run(self):
+        # resolve best of 3
+        if not self.message:
+            return
+
+        embed = discord.Embed(title="PvP Match", color=discord.Color.blurple())
+        embed.description = f"{player_label(self.challenger)} vs {player_label(self.opponent)}\nStarting match..."
+        await self.message.edit(embed=embed, view=None)
+
+        # Round by round: show power ranges first, then reveal rolls and winner
+        for i in range(3):
+            a_card = self.teams[self.challenger.id][i]
+            b_card = self.teams[self.opponent.id][i]
+
+            # determine configured ranges for each card's tier
+            ranges = self.settings.get("power_ranges", {})
+            a_tier = a_card._tier if hasattr(a_card, "_tier") else a_card.tier[1]
+            b_tier = b_card._tier if hasattr(b_card, "_tier") else b_card.tier[1]
+            a_rng = ranges.get(a_tier, [1, 100])
+            b_rng = ranges.get(b_tier, [1, 100])
+
+            # Determine RPS bonus percentages for preview (attacker perspective)
+            a_bonus_pct = rps_bonus_pct(a_tier, b_tier)
+            b_bonus_pct = rps_bonus_pct(b_tier, a_tier)
+
+            # Send range embed (secret: we show range but not rolled values)
+            range_embed = discord.Embed(title=f"Round {i+1} — Power Ranges", color=discord.Color.random())
+            a_field = f"🎲 {a_card._tier.capitalize()}: {int(a_rng[0])} - {int(a_rng[1])}"
+            if a_bonus_pct > 0:
+                a_field += f"\n🔺 +{int(a_bonus_pct*100)}% (RPS bonus)"
+            b_field = f"🎲 {b_card._tier.capitalize()}: {int(b_rng[0])} - {int(b_rng[1])}"
+            if b_bonus_pct > 0:
+                b_field += f"\n🔺 +{int(b_bonus_pct*100)}% (RPS bonus)"
+
+            range_embed.add_field(name=f"{self.challenger.display_name}", value=a_field, inline=True)
+            range_embed.add_field(name=f"{self.opponent.display_name}", value=b_field, inline=True)
+            range_embed.set_footer(text="A secret roll will be revealed shortly...")
+
+            # Try to show a stitched preview image without highlight
+            try:
+                range_img = await compose_vs_image(a_card, b_card, highlight=None, size_rate=0.28)
+                fname_range = f"round_{i+1}_range.webp"
+                file_range = discord.File(range_img, filename=fname_range)
+                range_msg = await self.message.channel.send(embed=range_embed, file=file_range)
+            except Exception as e:
+                try:
+                    func.logger.exception(f"Failed to compose/send range image for match {self.challenger.id} vs {self.opponent.id} (round {i+1}): {e}")
+                except Exception:
+                    pass
+                range_msg = await self.message.channel.send(embed=range_embed)
+
+            # wait to reveal the roll
+            await asyncio.sleep(self.settings.get("round_delay", 4))
+
+            # perform the secret rolls now
+            # We'll compute raw roll, include stars, then apply RPS bonus to that subtotal.
+            a_raw = random.randint(int(a_rng[0]), int(a_rng[1]))
+            b_raw = random.randint(int(b_rng[0]), int(b_rng[1]))
+            a_stars = getattr(a_card, "stars", 0)
+            b_stars = getattr(b_card, "stars", 0)
+
+            a_base = a_raw + a_stars
+            b_base = b_raw + b_stars
+
+            a_bonus_amt = int(a_base * a_bonus_pct)
+            b_bonus_amt = int(b_base * b_bonus_pct)
+
+            a_total = a_base + a_bonus_amt
+            b_total = b_base + b_bonus_amt
+
+            # resolve ties with rerolls (reroll raw values and recompute totals)
+            attempts = 0
+            while a_total == b_total and attempts < self.settings.get("max_reroll_attempts", 20):
+                a_raw = random.randint(int(a_rng[0]), int(a_rng[1]))
+                b_raw = random.randint(int(b_rng[0]), int(b_rng[1]))
+                a_base = a_raw + a_stars
+                b_base = b_raw + b_stars
+                a_bonus_amt = int(a_base * a_bonus_pct)
+                b_bonus_amt = int(b_base * b_bonus_pct)
+                a_total = a_base + a_bonus_amt
+                b_total = b_base + b_bonus_amt
+                attempts += 1
+
+            # determine round winner and highlight side
+            if a_total > b_total:
+                winner = self.challenger
+                self.wins[self.challenger.id] += 1
+                result_str = f"{player_label(self.challenger)} wins Round {i+1}! ({a_total} vs {b_total})"
+                highlight = "left"
+            elif b_total > a_total:
+                winner = self.opponent
+                self.wins[self.opponent.id] += 1
+                result_str = f"{player_label(self.opponent)} wins Round {i+1}! ({b_total} vs {a_total})"
+                highlight = "right"
+            else:
+                winner = None
+                result_str = f"Round {i+1} is a tie after {attempts} rerolls. ({a_total} vs {b_total})"
+                highlight = None
+
+            # Build the reveal embed showing rolled powers and winner
+            reveal_embed = discord.Embed(title=f"Round {i+1} — Result", color=discord.Color.random())
+
+            # Helper to build the value string with breakdown (returns list of lines)
+            def build_breakdown(tier_name, rng, raw, stars, bonus_amt, bonus_pct):
+                lines = []
+                lines.append(f"🎲 {tier_name.capitalize()}: {int(rng[0])}-{int(rng[1])}")
+                lines.append(f"🎲 Roll: {raw}")
+                if stars:
+                    lines.append(f"⭐ Stars: {stars}")
+                rolled = (raw + (stars or 0))
+                # Show Bonus line only when > 0; Total is basic when no bonus
+                if bonus_amt > 0:
+                    lines.append(f"➕ Bonus: {bonus_amt} (+{int(bonus_pct*100)}%)")
+                    lines.append(f"🧮 Total: { (rolled + bonus_amt) } ({rolled} + {bonus_amt} power)")
+                else:
+                    lines.append(f"🧮 Total: { rolled }")
+                return lines
+
+            # Build breakdowns for both players
+            a_lines = build_breakdown(a_card._tier, a_rng, a_raw, a_stars, a_bonus_amt, a_bonus_pct)
+            b_lines = build_breakdown(b_card._tier, b_rng, b_raw, b_stars, b_bonus_amt, b_bonus_pct)
+
+            # If one side has a Bonus line and the other doesn't, insert an explicit zero-bonus line into the other
+            a_has_bonus = any(l.startswith('➕ Bonus') for l in a_lines)
+            b_has_bonus = any(l.startswith('➕ Bonus') for l in b_lines)
+            if a_has_bonus and not b_has_bonus:
+                # insert zero bonus before the total and replace the Total line with breakdown form
+                b_lines.insert(-1, f"➕ Bonus: 0 (+0%)")
+                b_rolled = b_raw + b_stars
+                b_lines[-1] = f"🧮 Total: {b_rolled} ({b_rolled} + 0 power)"
+            elif b_has_bonus and not a_has_bonus:
+                a_lines.insert(-1, f"➕ Bonus: 0 (+0%)")
+                a_rolled = a_raw + a_stars
+                a_lines[-1] = f"🧮 Total: {a_rolled} ({a_rolled} + 0 power)"
+
+            # Ensure both sides have the same number of lines by padding with invisible lines if needed
+            max_len = max(len(a_lines), len(b_lines))
+            pad_token = '\u200b'  # zero-width space — invisible but keeps vertical spacing
+            if len(a_lines) < max_len:
+                a_lines += [pad_token] * (max_len - len(a_lines))
+            if len(b_lines) < max_len:
+                b_lines += [pad_token] * (max_len - len(b_lines))
+
+            reveal_embed.add_field(name=f"{self.challenger.display_name}", value="\n".join(a_lines), inline=True)
+            reveal_embed.add_field(name=f"{self.opponent.display_name}", value="\n".join(b_lines), inline=True)
+            reveal_embed.set_footer(text=result_str)
+
+            # Compose reveal image with highlight and send; then remove the range message
+            try:
+                reveal_img = await compose_vs_image(a_card, b_card, highlight=highlight, size_rate=0.28)
+                fname_reveal = f"round_{i+1}_reveal.webp"
+                file_reveal = discord.File(reveal_img, filename=fname_reveal)
+                await self.message.channel.send(embed=reveal_embed, file=file_reveal)
+            except Exception as e:
+                try:
+                    func.logger.exception(f"Compose failed for reveal images, falling back to separate attachments: {e}")
+                except Exception:
+                    pass
+                try:
+                    a_bytes = await a_card.image_bytes()
+                    b_bytes = await b_card.image_bytes()
+                    fname_a = f"card_a_{i+1}.webp"
+                    fname_b = f"card_b_{i+1}.webp"
+                    file_a = discord.File(a_bytes, filename=fname_a)
+                    file_b = discord.File(b_bytes, filename=fname_b)
+                    reveal_embed.set_image(url=f"attachment://{fname_a}")
+                    reveal_embed.set_thumbnail(url=f"attachment://{fname_b}")
+                    await self.message.channel.send(embed=reveal_embed, files=[file_a, file_b])
+                except Exception:
+                    try:
+                        func.logger.exception(f"Failed to send fallback reveal images for match {self.challenger.id} vs {self.opponent.id} (round {i+1}): {e}")
+                    except Exception:
+                        pass
+                    await self.message.channel.send(embed=reveal_embed)
+
+            # try to delete the earlier range message to visually replace it with the reveal
+            try:
+                await range_msg.delete()
+            except Exception:
+                pass
+
+            # pause briefly after reveal
+            await asyncio.sleep(self.settings.get("post_round_delay", 3))
+
+        # determine match winner
+        if self.wins[self.challenger.id] > self.wins[self.opponent.id]:
+            match_winner = self.challenger
+        elif self.wins[self.opponent.id] > self.wins[self.challenger.id]:
+            match_winner = self.opponent
+        else:
+            match_winner = None
+
+        # Update PVP stats for both players
+        try:
+            # Update challenger stats
+            if match_winner == self.challenger:
+                await func.update_user(self.challenger.id, {
+                    "$inc": {"pvp.wins": 1, "pvp.total_matches": 1}
+                })
+                await func.update_user(self.opponent.id, {
+                    "$inc": {"pvp.losses": 1, "pvp.total_matches": 1}
+                })
+            elif match_winner == self.opponent:
+                await func.update_user(self.challenger.id, {
+                    "$inc": {"pvp.losses": 1, "pvp.total_matches": 1}
+                })
+                await func.update_user(self.opponent.id, {
+                    "$inc": {"pvp.wins": 1, "pvp.total_matches": 1}
+                })
+            else:
+                # Draw - just increment total matches for both
+                await func.update_user(self.challenger.id, {
+                    "$inc": {"pvp.total_matches": 1}
+                })
+                await func.update_user(self.opponent.id, {
+                    "$inc": {"pvp.total_matches": 1}
+                })
+        except Exception as e:
+            try:
+                func.logger.exception(f"Failed to update PVP stats: {e}")
+            except Exception:
+                pass
+
+        final_embed = discord.Embed(title="PvP Match Result", color=discord.Color.gold())
+        if match_winner:
+            final_embed.description = f"Winner: {match_winner.mention}\nScore: {self.wins[self.challenger.id]} - {self.wins[self.opponent.id]}"
+        else:
+            final_embed.description = f"Match ended in a draw.\nScore: {self.wins[self.challenger.id]} - {self.wins[self.opponent.id]}"
+
+        await self.message.channel.send(embed=final_embed)
+
+        # === REWARD FLOW: offer three hidden cards from the loser for the winner to pick one ===
+        if not func.settings.PVP_REWARDS_ENABLED :
+            return
+
+        try:
+            if match_winner is None:
+                return
+
+            loser = self.challenger if match_winner.id == self.opponent.id else self.opponent
+
+            # fetch latest user docs
+            loser_doc = await func.get_user(loser.id)
+            winner_doc = await func.get_user(match_winner.id)
+
+            # get candidate cards (ensure ownership still matches)
+            candidate_ids = [c for c in loser_doc.get("cards", []) if (card_obj := CardPool.get_card(str(c))) and card_obj.owner_id == loser.id]
+
+            if not candidate_ids:
+                await self.message.channel.send(f"No available cards to be rewarded from {player_label(loser)}.")
+                return
+
+            # pick up to three random distinct candidate ids
+            sample_size = min(3, len(candidate_ids))
+            reward_ids = random.sample(candidate_ids, k=sample_size)
+            reward_cards = [CardPool.get_card(str(cid)) for cid in reward_ids]
+
+            # shuffle the offered cards so positions are random
+            random.shuffle(reward_cards)
+
+            # Define Reward UI classes
+            class RewardButton(discord.ui.Button):
+                def __init__(self, card: Card, *, idx: int):
+                    # Do NOT show rarity emoji here; keep images hidden from fields and only show stitched cover
+                    super().__init__(label=f"Pick {idx}", style=discord.ButtonStyle.green)
+                    self.card = card
+                    self.idx = idx
+
+                async def callback(self, interaction: discord.Interaction):
+                    # Only winner may pick
+                    if interaction.user.id != match_winner.id:
+                        return await interaction.response.send_message("Only the match winner can pick a reward.", ephemeral=True)
+
+                    async with self.view._lock:
+                        # re-check availability
+                        if self.card.owner_id != loser.id:
+                            return await interaction.response.send_message("This card is no longer available.", ephemeral=True)
+
+                        # check winner inventory limit
+                        _winner = await func.get_user(match_winner.id)
+                        if (len(_winner.get("cards", [])) + 1) > func.get_user_card_limit(_winner):
+                            return await interaction.response.send_message("Your inventory is full. Please free some space before claiming the reward.", ephemeral=True)
+
+                        # perform transfer: in-memory
+                        self.card.change_owner(match_winner.id)
+                        last_trade_time = time.time()
+                        self.card.last_trade_time = last_trade_time
+
+                        # DB updates: remove from loser, add to winner, update card owner
+                        await func.update_user(loser.id, {"$pull": {"cards": self.card.id}})
+
+                        winner_query = func.update_quest_progress(_winner, ["COLLECT_ANY_CARD", f"COLLECT_{self.card._tier.upper()}_CARD"], query={
+                            "$push": {"cards": self.card.id},
+                            "$inc": {"exp": 10}
+                        })
+                        await func.update_user(match_winner.id, winner_query)
+
+                        await func.update_card(self.card.id, {"$set": {"owner_id": match_winner.id, "last_trade_time": last_trade_time}})
+
+                        func.logger.info(f"PvP reward: User {match_winner.name}({match_winner.id}) took card {self.card.id} from {loser.name}({loser.id})")
+
+                        # disable view and update UI to show selection
+                        for ch in self.view.children:
+                            ch.disabled = True
+                        self.view.stop()
+
+                        # send confirmation and reveal the card image
+                        try:
+                            image_bytes = await self.card.image_bytes()
+                            file = discord.File(image_bytes, filename=f"reward_{self.card.id}.webp")
+                            embed = discord.Embed(title="🏆 PvP Reward", color=discord.Color.gold())
+                            embed.description = f"{player_label(match_winner)} picked {self.card.display_id} from {player_label(loser)}"
+                            await interaction.response.send_message(embed=embed, file=file)
+                        except Exception:
+                            await interaction.response.send_message(f"{player_label(match_winner)} picked {self.card.display_id} from {player_label(loser)}")
+
+            class RewardView(discord.ui.View):
+                def __init__(self, cards: list[Card], timeout: float | None = 60):
+                    super().__init__(timeout=timeout)
+                    self._lock = asyncio.Lock()
+                    for idx, c in enumerate(cards, start=1):
+                        self.add_item(RewardButton(c, idx=idx))
+
+                async def on_timeout(self) -> None:
+                    for child in self.children:
+                        child.disabled = True
+                    try:
+                        await reward_message.edit(content="*🕟 Reward selection expired.*", view=self)
+                    except Exception:
+                        pass
+                    self.stop()
+
+            # Build and send reward embed with a stitched image of the three cover images
+            reward_embed = discord.Embed(title="PvP Reward — Choose one card", color=discord.Color.green())
+            reward_embed.description = f"{player_label(match_winner)}, pick one card taken from {player_label(loser)}. Click the button under the image to pick."
+
+            try:
+                # Use cover images to hide the real cards (level1.webp / level2.webp / level3.webp)
+                stitched = await compose_three_image(reward_cards, size_rate=0.28, use_cover=True)
+                file = discord.File(stitched, filename="pvp_reward_three.webp")
+                reward_embed.set_image(url=f"attachment://pvp_reward_three.webp")
+                view = RewardView(reward_cards, timeout=60)
+                reward_message = await self.message.channel.send(embed=reward_embed, file=file, view=view)
+            except Exception as e:
+                # fallback to non-image embed listing (shouldn't normally happen)
+                try:
+                    func.logger.exception(f"Failed to compose three-card reward image: {e}")
+                except Exception:
+                    pass
+                view = RewardView(reward_cards, timeout=60)
+                reward_message = await self.message.channel.send(embed=reward_embed, view=view)
+
+        except Exception as e:
+            try:
+                func.logger.exception(f"Error in PvP reward flow: {e}")
+            except Exception:
+                pass
+
+
+class TeamModal(discord.ui.Modal):
+    def __init__(self, match: PvPMatch, for_user_id: int):
+        super().__init__(title="Submit 3 cards, different tiers, no celestial")
+        self.match = match
+        self.for_user_id = for_user_id
+
+        self.card1 = discord.ui.TextInput(label="Card 1 ID / Tag", placeholder="e.g. 123", required=True, max_length=64)
+        self.card2 = discord.ui.TextInput(label="Card 2 ID / Tag", placeholder="e.g. 456", required=True, max_length=64)
+        self.card3 = discord.ui.TextInput(label="Card 3 ID / Tag", placeholder="e.g. 789", required=True, max_length=64)
+
+        self.add_item(self.card1)
+        self.add_item(self.card2)
+        self.add_item(self.card3)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        # validate the submission
+        user_id = interaction.user.id
+        if user_id != self.for_user_id:
+            return await interaction.response.send_message("This submission isn't for you.", ephemeral=True)
+
+        entries = [self.card1.value.strip(), self.card2.value.strip(), self.card3.value.strip()]
+        # check uniqueness
+        if len(set(entries)) != 3:
+            return await interaction.response.send_message("Cards must be unique.", ephemeral=True)
+
+        # resolve cards
+        resolved = CardPool.search_valid_cards(entries)
+        if len(resolved) != 3:
+            return await interaction.response.send_message("One or more card IDs/tags are invalid.", ephemeral=True)
+
+        # ownership check
+        user_doc = await func.get_user(user_id)
+        owned_ids = set(str(x).lstrip("0") for x in user_doc.get("cards", []))
+        for c in resolved:
+            if str(c.id) not in owned_ids and (not c.owner_id or c.owner_id != user_id):
+                return await interaction.response.send_message("You must own all the cards you submit.", ephemeral=True)
+
+        # check for celestial cards - not allowed in PvP
+        for c in resolved:
+            if c._tier.lower() == "celestial":
+                return await interaction.response.send_message("Celestial cards are not allowed in PvP matches.", ephemeral=True)
+
+        # check tier uniqueness - all cards must have different tier types
+        tiers = [c._tier for c in resolved]
+        if len(set(tiers)) != 3:
+            return await interaction.response.send_message("All 3 cards must have different tier types.", ephemeral=True)
+
+        # store the team
+        self.match.teams[user_id] = resolved
+
+        # update the match message to show submission status
+        try:
+            if self.match.message:
+                embed = discord.Embed(title="Team Submission", color=discord.Color.blue())
+                challenger_status = "✅ Submitted" if self.match.challenger.id in self.match.teams else "⏳ Waiting"
+                opponent_status = "✅ Submitted" if self.match.opponent.id in self.match.teams else "⏳ Waiting"
+                embed.description = f"{player_label(self.match.challenger)}: {challenger_status}\n{player_label(self.match.opponent)}: {opponent_status}"
+                await self.match.message.edit(embed=embed, view=self.match_message_view())
+        except Exception:
+            pass
+
+        await interaction.response.send_message("Team submitted.", ephemeral=True)
+
+        # if both ready, run match
+        if self.match.is_ready():
+            # run match in background
+            asyncio.create_task(self.match.run())
+
+    def match_message_view(self) -> discord.ui.View:
+        # keep simple view showing submit buttons for remaining players
+        view = SubmissionView(self.match)
+        return view
+
+
+class SubmitButton(discord.ui.Button):
+    def __init__(self, match: PvPMatch, target_user_id: int, label: str):
+        super().__init__(label=label, style=discord.ButtonStyle.primary)
+        self.match = match
+        self.target_user_id = target_user_id
+
+    async def callback(self, interaction: discord.Interaction):
+        # only allow the intended user to open their modal
+        if interaction.user.id != self.target_user_id:
+            return await interaction.response.send_message("This button isn't for you.", ephemeral=True)
+
+        # open modal for this user
+        modal = TeamModal(self.match, self.target_user_id)
+        await interaction.response.send_modal(modal)
+
+
+class SubmissionView(discord.ui.View):
+    def __init__(self, match: PvPMatch, timeout: float = None):
+        super().__init__(timeout=timeout)
+        self.match = match
+        # add two submit buttons targeted to each player
+        self.add_item(SubmitButton(match, match.challenger.id, f"Submit: {match.challenger.display_name}"))
+        self.add_item(SubmitButton(match, match.opponent.id, f"Submit: {match.opponent.display_name}"))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        # Only allow the challenger or opponent to interact with submission view
+        return interaction.user.id in (self.match.challenger.id, self.match.opponent.id)
+
+    async def on_timeout(self) -> None:
+        try:
+            if self.match.message:
+                await self.match.message.edit(content="Submission period expired.", view=None)
+        except Exception:
+            pass
+
+
+class ChallengeView(discord.ui.View):
+    def __init__(self, ctx: commands.Context, challenger: discord.Member, opponent: Optional[discord.Member] = None, timeout: float = None):
+        super().__init__(timeout=timeout)
+        self.ctx = ctx
+        self.challenger = challenger
+        self.opponent = opponent
+        self.settings = get_pvp_settings()
+        self.match: Optional[PvPMatch] = None
+        self.message: Optional[discord.Message] = None
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.green)
+    async def accept(self, interaction: discord.Interaction, button: discord.ui.Button):
+        # Check acceptance rules
+        if self.opponent and interaction.user.id != self.opponent.id:
+            return await interaction.response.send_message("This challenge is not for you.", ephemeral=True)
+
+        # Prevent the challenger from accepting their own challenge (covers open challenges)
+        if interaction.user.id == self.challenger.id:
+            return await interaction.response.send_message("You cannot accept your own challenge.", ephemeral=True)
+
+        # create PvPMatch
+        opponent = interaction.user
+        challenger = self.challenger
+        self.match = PvPMatch(self.ctx, challenger, opponent, self.settings)
+
+        # send submission message with view containing targeted submit buttons
+        embed = discord.Embed(title="PvP Match - Team Submission", color=discord.Color.blurple())
+        embed.description = f"{player_label(challenger)} vs {player_label(opponent)}\nBoth players, please submit your teams (3 unique cards with different tier types, celestial not allowed) by clicking your Submit button below. You must own the cards you submit."
+
+        # replace buttons with submission view
+        view = SubmissionView(self.match, timeout=self.settings.get("challenge_timeout", 300))
+
+        try:
+            # edit original message to show the submission UI
+            await self.message.edit(content=None, embed=embed, view=view)
+            self.match.message = self.message
+            await interaction.response.send_message("Match accepted. Submit your team using the buttons in the match message.", ephemeral=True)
+        except Exception:
+            # fallback: send a new message
+            sent = await self.ctx.send(embed=embed, view=view)
+            self.match.message = sent
+            await interaction.response.send_message("Match accepted. Submit your team using the buttons in the match message.", ephemeral=True)
+
+        # stop this view from accepting further accepts
+        for child in self.children:
+            child.disabled = True
+        self.stop()
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red)
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.challenger.id:
+            return await interaction.response.send_message("Only the challenger can cancel this challenge.", ephemeral=True)
+        for child in self.children:
+            child.disabled = True
+        try:
+            await self.message.edit(content="Challenge canceled.", view=self)
+        except Exception:
+            pass
+        await interaction.response.send_message("Challenge canceled.", ephemeral=True)
+        self.stop()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        # Allow only challenger or the intended opponent (if set) to interact with initial challenge view
+        if interaction.user.id == self.challenger.id:
+            return True
+        if self.opponent and interaction.user.id == self.opponent.id:
+            return True
+        if not self.opponent:
+            # open challenge — anyone can accept except the challenger
+            return interaction.user.id != self.challenger.id
+        return False
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        try:
+            if self.message:
+                await self.message.edit(content="Challenge expired.", view=self)
+        except Exception:
+            pass
+        self.stop()

--- a/views/quiz.py
+++ b/views/quiz.py
@@ -223,41 +223,47 @@ class QuizView(discord.ui.View):
                             f"{'🕘 Avg Time:':<12} {func.convert_seconds(average_time)} {'🔺' if average_time < state['average_time'] else '🔻'}\n" \
                             f"{'🔥 Points:':<12} {state['points']} ({'+' if total_points >= 0 else '-'}{abs(total_points)})```"
 
-        if new_record:
-            rank: tuple[str, int] = QP.get_rank(state["points"])
-            highest_rank: tuple[str, int] = QP.get_rank(old_highest_points)
-            rank_list = list(func.settings.RANK_BASE.keys())
+        # Feature flag: Use reward card system or traditional rewards
+        use_reward_card = func.settings.GIVE_REWARD_CARD
 
-            if rank[0] in rank_list[rank_list.index(highest_rank[0]) + 1:]:
-                embed.description += f"\n<:{rank[0]}:{rank[1]}> **{rank[0].title()} Promotion Rewards**```"
-                for index, reward in func.settings.RANK_BASE[rank[0]]["rewards"].items():
-                    if isinstance(reward[0], list):
-                        reward = choice(reward)
-                    
-                    reward_name, amount = reward
-                    if "$inc" not in query:
-                        query["$inc"] = {}
 
-                    query["$inc"][reward_name] = amount
-                    reward_name = reward_name.split(".")
+        if not use_reward_card:
+            # Traditional reward system (promotion rewards)
+            if new_record:
+                rank: tuple[str, int] = QP.get_rank(state["points"])
+                highest_rank: tuple[str, int] = QP.get_rank(old_highest_points)
+                rank_list = list(func.settings.RANK_BASE.keys())
 
-                    embed.description += f"{index}. "
-                    if reward_name[0] == "candies":
-                        embed.description += f"{'🍬 Candies':<18} x{amount}\n"
-                    
-                    elif reward_name[0] == "roll":
-                        roll_data = func.settings.TIERS_BASE.get(reward_name[1])
-                        embed.description += f"{roll_data[0]} {reward_name[1].title() + ' Roll':<16} x{amount}\n"
+                if rank[0] in rank_list[rank_list.index(highest_rank[0]) + 1:]:
+                    embed.description += f"\n<:{rank[0]}:{rank[1]}> **{rank[0].title()} Promotion Rewards**```"
+                    for index, reward in func.settings.RANK_BASE[rank[0]]["rewards"].items():
+                        if isinstance(reward[0], list):
+                            reward = choice(reward)
+                        
+                        reward_name, amount = reward
+                        if "$inc" not in query:
+                            query["$inc"] = {}
 
-                    elif reward_name[0] == "exp":
-                        embed.description += f"{'⚔️ Exp':<19} x{amount}\n"
+                        query["$inc"][reward_name] = amount
+                        reward_name = reward_name.split(".")
 
-                    else:
-                        reward_name = reward_name[1].split("_")
-                        potion_data = func.settings.POTIONS_BASE.get(reward_name[0])
-                        embed.description += f"{potion_data.get('emoji') + ' ' + reward_name[0].title() + ' ' + reward_name[1].upper() + ' Potion':<18} x{amount}\n"
+                        embed.description += f"{index}. "
+                        if reward_name[0] == "candies":
+                            embed.description += f"{'🍬 Candies':<18} x{amount}\n"
+                        
+                        elif reward_name[0] == "roll":
+                            roll_data = func.settings.TIERS_BASE.get(reward_name[1])
+                            embed.description += f"{roll_data[0]} {reward_name[1].title() + ' Roll':<16} x{amount}\n"
 
-                embed.description += "```"
+                        elif reward_name[0] == "exp":
+                            embed.description += f"{'⚔️ Exp':<19} x{amount}\n"
+
+                        else:
+                            reward_name = reward_name[1].split("_")
+                            potion_data = func.settings.POTIONS_BASE.get(reward_name[0])
+                            embed.description += f"{potion_data.get('emoji') + ' ' + reward_name[0].title() + ' ' + reward_name[1].upper() + ' Potion':<18} x{amount}\n"
+
+                    embed.description += "```"
 
         await func.update_user(self.author.id, query)
 
@@ -272,6 +278,59 @@ class QuizView(discord.ui.View):
         )
 
         await self.response.edit(content="This quiz has expired.", embed=embed, view=None)
+        
+        # Feature flag: Give reward card based on points
+        if use_reward_card and state['points'] > 0:
+            try:
+                from .reward_card import RewardCardView
+                
+                # Determine probabilities based on points
+                probs_config = func.settings.REWARD_CARD_PROBABILITIES or {}
+                probs_config = probs_config.get("NORMAL_QUIZ", {})
+                # Find the appropriate tier based on current points.
+                # If the score is below the first configured threshold, fall back to the lowest tier
+                # so a positive-score quiz still produces a reward card.
+                current_points = state['points']
+                selected_probs = None
+                thresholds = sorted((int(threshold_str), threshold_str) for threshold_str in probs_config.keys())
+                for threshold, threshold_str in thresholds:
+                    if current_points >= threshold:
+                        selected_probs = probs_config[threshold_str]
+
+                if selected_probs is None and current_points > 0 and thresholds:
+                    selected_probs = probs_config[thresholds[0][1]]
+                
+                if selected_probs:
+                    # Create and send reward card view
+                    reward_view = RewardCardView(None, self.author, selected_probs, initial_cost=10, cost_currency_field="candies", timeout=120)
+                    await reward_view._roll_card()
+                    
+                    reward_embed = reward_view.build_embed()
+                    file = None
+                    if reward_view.current_card:
+                        try:
+                            img_bytes = await reward_view.current_card.image_bytes()
+                            filename = f"{reward_view.current_card.id}.webp"
+                            file = discord.File(img_bytes, filename=filename)
+                            reward_embed.set_image(url=f"attachment://{filename}")
+                        except Exception:
+                            file = None
+                    
+                    reward_content = f"**{self.author.mention} This reward ends <t:{reward_view.expires_at}:R>**\n🎁 Card reward for reaching {current_points} points!"
+                    reward_msg = await self.response.channel.send(
+                        content=reward_content,
+                        embed=reward_embed,
+                        file=file,
+                        view=reward_view
+                    )
+                    reward_view.message = reward_msg
+            except Exception:
+                # Fail silently but log
+                try:
+                    func.logger.exception("Failed to present normal quiz reward card view")
+                except:
+                    pass
+        
         self.stop()
         
     def build_embed(self) -> discord.Embed:

--- a/views/reward_card.py
+++ b/views/reward_card.py
@@ -1,0 +1,300 @@
+import discord, time, random, asyncio
+from typing import Dict, Optional
+from discord.ext import commands
+
+import functions as func
+from iufi import CardPool, Card
+
+
+class RewardCardView(discord.ui.View):
+    """A reward card view with Claim and Reroll functionality.
+
+    Usage:
+        view = RewardCardView(ctx, author, probabilities, initial_cost=10)
+        await view.send()
+
+    Arguments:
+        ctx: commands.Context (used for sending messages and invoking commands)
+        author: the only discord.Member allowed to interact with the view
+        probabilities: mapping of card tier name -> weight (floats or ints). They will be normalized.
+        initial_cost: starting cost (in the user's currency field) for reroll
+        cost_currency_field: which user field represents currency (default: "candies")
+        timeout: view expiry in seconds (default: 120)
+        cost_multiplier: how much the reroll cost multiplies after each reroll (default: 2.0)
+    """
+
+    def __init__(
+        self,
+        ctx: Optional[commands.Context],
+        author: discord.Member,
+        probabilities: Dict[str, float],
+        *,
+        initial_cost: int = 10,
+        cost_currency_field: str = "candies",
+        timeout: float = 120,
+        cost_multiplier: float = 2.0,
+    ) -> None:
+        super().__init__(timeout=timeout)
+
+        self.ctx = ctx
+        self.author = author
+        self._raw_probs = probabilities or {}
+        self._weights = self._normalize_probs(self._raw_probs)
+        self.initial_cost = max(0, int(initial_cost))
+        self.current_cost = self.initial_cost
+        self.cost_currency_field = cost_currency_field
+        self.cost_multiplier = float(cost_multiplier)
+        self.timeout_seconds = timeout
+        # expiry unix timestamp (rounded int) used for Discord-friendly timestamps
+        self.expires_at: int = round(time.time() + self.timeout_seconds)
+
+        self._lock = asyncio.Lock()
+        self.message: discord.Message | None = None
+        self.current_card: Card | None = None
+        self.rerolls: int = 0
+
+        # prepare buttons
+        # Claim and Reroll added as UI items
+
+    def _normalize_probs(self, probs: Dict[str, float]) -> Dict[str, float]:
+        if not probs:
+            return {}
+        items = {k: float(v) for k, v in probs.items() if v and v > 0}
+        total = sum(items.values())
+        if total <= 0:
+            # fallback equal weights
+            n = len(items) or 1
+            return {k: 1 / n for k in items}
+        return {k: v / total for k, v in items.items()}
+
+    def _format_probs(self) -> str:
+        if not self._weights:
+            return "No probabilities provided."
+        lines = []
+        for tier, w in sorted(self._weights.items(), key=lambda i: -i[1]):
+            emoji = func.settings.TIERS_BASE.get(tier, ["?"])[0]
+            lines.append(f"{emoji} {tier.capitalize()}: {round(w * 100, 2)}%")
+        return "\n".join(lines)
+
+    def _choose_tier(self) -> str | None:
+        if not self._weights:
+            return None
+        tiers = list(self._weights.keys())
+        weights = list(self._weights.values())
+        return random.choices(tiers, weights=weights, k=1)[0]
+
+    def _pick_card_from_tier(self, tier: str) -> Card | None:
+        # pick a random available card for the tier
+        try:
+            pool = CardPool
+            avail = pool._available_cards.get(tier, [])
+            if not avail:
+                # fallback: find any available card
+                for cards in pool._available_cards.values():
+                    if cards:
+                        return random.choice(cards)
+                return None
+
+            return random.choice(avail)
+        except Exception:
+            return None
+
+    async def _roll_card(self) -> Card | None:
+        tier = self._choose_tier()
+        card = None
+        if tier:
+            card = self._pick_card_from_tier(tier)
+        # final fallback
+        if not card:
+            # try CardPool.roll to obtain a category first
+            try:
+                cards = CardPool.roll(1)
+                card = cards[0] if cards else None
+            except Exception:
+                card = None
+        self.current_card = card
+        return card
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(title=f"Reward Card — Expires <t:{self.expires_at}:R>", color=discord.Color.random())
+        embed.add_field(name="Probabilities", value=self._format_probs(), inline=False)
+
+        if self.current_card:
+            card = self.current_card
+            embed.description = f"{card.tier[0]} **{card._tier.capitalize()}** | {card.display_id} | {card.display_stars}"
+            embed.set_footer(text=f"Reroll cost: {self.current_cost} {self.cost_currency_field}")
+        else:
+            embed.description = "No card available to display."
+            embed.set_footer(text=f"Reroll cost: {self.current_cost} {self.cost_currency_field}")
+
+        return embed
+
+    async def send(self) -> discord.Message:
+        # roll initial card
+        await self._roll_card()
+
+        embed = self.build_embed()
+        file = None
+        if self.current_card:
+            try:
+                img_bytes = await self.current_card.image_bytes()
+                filename = f"{self.current_card.id}.webp"
+                file = discord.File(img_bytes, filename=filename)
+                embed.set_image(url=f"attachment://{filename}")
+            except Exception:
+                file = None
+
+        # include friendly discord timestamp in the message content for automatic relative display
+        content = f"**{self.author.mention} This reward ends <t:{self.expires_at}:R>**"
+        # ctx could be None if the caller intends to send the message manually (some views call RewardCardView without ctx)
+        if self.ctx:
+            self.message = await self.ctx.send(content=content, embed=embed, file=file, view=self)
+        else:
+            # fallback: no ctx provided; leave message unset — caller should send the embed and attach the view
+            self.message = None
+        return self.message
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        # Only allow the provided author to interact with the view
+        if interaction.user != self.author:
+            await interaction.response.send_message("Only the user who opened this reward can interact with it.", ephemeral=True)
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+            child.style = discord.ButtonStyle.gray
+        try:
+            if self.message:
+                await self.message.edit(content=f"*⏰ This reward has expired. (expired <t:{round(time.time())}:R>)*", view=self)
+        except Exception:
+            pass
+        self.stop()
+
+    @discord.ui.button(label="Claim", style=discord.ButtonStyle.green)
+    async def claim(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        async with self._lock:
+            if not self.current_card:
+                return await interaction.response.send_message("No card to claim.", ephemeral=True)
+
+            card = self.current_card
+            if (owner_id := card.owner_id):
+                if owner_id != interaction.user.id:
+                    return await interaction.response.send_message(f"This card has been claimed by <@{owner_id}>.", ephemeral=True)
+                else:
+                    return await interaction.response.send_message("You already own this card.", ephemeral=True)
+
+            user = await func.get_user(interaction.user.id)
+            # Check inventory limit
+            if len(user.get("cards", [])) >= func.get_user_card_limit(user):
+                return await interaction.response.send_message("Your inventory is full.", ephemeral=True)
+
+            # Claim the card
+            button.disabled = True
+            button.style = discord.ButtonStyle.gray
+            # disable reroll as well
+            for child in self.children:
+                if child.label == "Reroll":
+                    child.disabled = True
+
+            # change owner and update DB
+            card.change_owner(interaction.user.id)
+            CardPool.remove_available_card(card)
+
+            actived_potions = func.get_potions(user.get("actived_potions", {}), func.settings.POTIONS_BASE)
+            query = func.update_quest_progress(user, ["COLLECT_ANY_CARD", f"COLLECT_{card._tier.upper()}_CARD"], query={
+                "$push": {"cards": card.id},
+                "$set": {"cooldown.claim": time.time() + (func.settings.COOLDOWN_BASE["claim"][1] * (1 - actived_potions.get("speed", 0)))},
+                "$inc": {"exp": 10}
+            })
+            await func.update_user(interaction.user.id, query)
+            await func.update_card(card.id, {"$set": {"owner_id": interaction.user.id}})
+
+            # Log successful claim
+            try:
+                func.logger.info(f"User {interaction.user.name}({interaction.user.id}) claimed reward card {card.id} ({card._tier}) via RewardCardView; rerolls={self.rerolls}")
+            except Exception:
+                pass
+
+            # update message
+            try:
+                embed = discord.Embed(title="Reward Claimed!", color=discord.Color.green())
+                embed.description = f"{interaction.user.mention} claimed {card.tier[0]} **{card._tier.capitalize()}** | {card.display_id} | {card.display_stars}"
+                if self.message:
+                    await self.message.edit(embed=embed, view=self)
+            except Exception:
+                pass
+
+            await interaction.response.send_message(f"You claimed {card.display_id}.", ephemeral=True)
+            self.stop()
+
+    @discord.ui.button(label="Reroll", style=discord.ButtonStyle.gray, emoji="🔁")
+    async def reroll(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        async with self._lock:
+            user = await func.get_user(interaction.user.id)
+            amount = user.get(self.cost_currency_field, 0)
+            if amount < self.current_cost:
+                return await interaction.response.send_message(f"You do not have enough {self.cost_currency_field} to reroll! (Need {self.current_cost})", ephemeral=True)
+
+            old_cost = self.current_cost
+            # Log reroll attempt and deduct cost
+            try:
+                func.logger.info(f"User {interaction.user.name}({interaction.user.id}) attempts reroll on reward card (cost={old_cost}).")
+            except Exception:
+                pass
+            # deduct cost
+            await func.update_user(interaction.user.id, {"$inc": {self.cost_currency_field: -old_cost}})
+
+            # roll a new card
+            await interaction.response.defer()
+            old_card = self.current_card
+            new_card = await self._roll_card()
+
+            # if we failed to obtain a new_card, restore currency and inform
+            if not new_card:
+                # give money back
+                await func.update_user(interaction.user.id, {"$inc": {self.cost_currency_field: old_cost}})
+                try:
+                    func.logger.info(f"Reroll failed for user {interaction.user.name}({interaction.user.id}); refunded {old_cost} {self.cost_currency_field}.")
+                except Exception:
+                    pass
+                return await interaction.followup.send("Failed to reroll. No cards available.", ephemeral=True)
+
+            # success: increment rerolls and update next cost
+            self.rerolls += 1
+            self.current_cost = max(0, int(old_cost * self.cost_multiplier))
+
+            # Log successful reroll
+            try:
+                func.logger.info(f"User {interaction.user.name}({interaction.user.id}) rerolled reward card: old_card={old_card.id if old_card else None} -> new_card={new_card.id if new_card else None}; spent={old_cost} {self.cost_currency_field}; next_cost={self.current_cost}; rerolls={self.rerolls}")
+            except Exception:
+                pass
+
+            # update embed and image
+            embed = self.build_embed()
+            file = None
+            try:
+                img_bytes = await new_card.image_bytes()
+                filename = f"{new_card.id}.webp"
+                file = discord.File(img_bytes, filename=filename)
+                embed.set_image(url=f"attachment://{filename}")
+            except Exception:
+                file = None
+
+            try:
+                if self.message:
+                    if file:
+                        await self.message.edit(embed=embed, attachments=[file], view=self)
+                    else:
+                        await self.message.edit(embed=embed, view=self)
+            except Exception:
+                try:
+                    await interaction.followup.send("Rerolled.", ephemeral=True)
+                except:
+                    pass
+
+            await interaction.followup.send(f"Rerolled to a new card. Next reroll cost: {self.current_cost} {self.cost_currency_field}", ephemeral=True)
+
+
+# End of file

--- a/views/shop.py
+++ b/views/shop.py
@@ -4,7 +4,8 @@ import functions as func
 SHOP_BASE: list[tuple[str, str, int]] = [
     (func.settings.TIERS_BASE.get("rare")[0], "roll.rare", 30),
     (func.settings.TIERS_BASE.get("epic")[0], "roll.epic", 100),
-    (func.settings.TIERS_BASE.get("legendary")[0], "roll.legendary", 250)
+    (func.settings.TIERS_BASE.get("legendary")[0], "roll.legendary", 250),
+    ("📦", "inventory.slots", 100)  # 1 extra card slot per purchase; base price is 100
 ]
 
 class QuantityModal(discord.ui.Modal):
@@ -56,6 +57,38 @@ class Dropdown(discord.ui.Select):
 
                 if modal.quantity:
                     user = await func.get_user(interaction.user.id)
+
+                    # Handle inventory slots (1 slot per purchase) differently because price increases with purchases
+                    if item[1] == "inventory.slots":
+                        # number of previous slot purchases made by the user
+                        prev_purchases = user.get("extra_props", {}).get("slot_purchases", 0)
+                        qty = modal.quantity
+                        base_price = item[2] if isinstance(item[2], int) else 100
+
+                        # compute total cost: sum of base_price + (prev_purchases + i) * 10 for each purchase
+                        total_price = 0
+                        for i in range(qty):
+                            total_price += base_price + (prev_purchases + i) * 10
+
+                        if user["candies"] < total_price:
+                            needed = total_price - user["candies"]
+                            return await interaction.followup.send(f"You don't have enough candies! You need `{needed}` more candies (price goes up as you purchase more slots).", ephemeral=True)
+
+                        # apply update: decrement candies, increment extra_card_slots by qty, increment slot_purchases by qty
+                        query = func.update_quest_progress(user, "BUY_ITEM", progress=modal.quantity, query={
+                            "$inc": {"candies": -total_price, "extra_props.extra_card_slots": modal.quantity, "extra_props.slot_purchases": modal.quantity}
+                        })
+
+                        await func.update_user(interaction.user.id, query)
+
+                        func.logger.info(f"User {interaction.user.name}({interaction.user.id}) purchased {modal.quantity} extra slot(s) for {total_price} candies.")
+
+                        embed = discord.Embed(title="🛒 Shop Purchase", color=discord.Color.random())
+                        embed.description = f"```{item[0]} + {modal.quantity} slot{'s' if modal.quantity > 1 else ''}\n🍬 - {total_price}```"
+
+                        return await interaction.followup.send(content="", embed=embed)
+
+                    # default behavior for other items
                     price = modal.quantity * item[2]
                     if user["candies"] < price:
                         return await interaction.followup.send(f"You don't have enough candies! You only have `{user['candies']}` candies", ephemeral=True)
@@ -95,7 +128,14 @@ class ShopView(discord.ui.View):
         embed.description = f"🍬 Starcandies: `{user.get('candies', 0)}`\n```"
         
         for item in SHOP_BASE:
-            embed.description += f"{item[0]} {(item[1].split('.')[1].title() + ' ' + item[1].split('.')[0].title()).upper():<20} {item[2]:>3} 🍬\n"
+            # For inventory slots, show the next price per slot based on user's purchases
+            if item[1] == "inventory.slots":
+                prev_purchases = user.get("extra_props", {}).get("slot_purchases", 0)
+                next_price = item[2] + prev_purchases * 10
+                display_price = f"{next_price} (per slot)"
+                embed.description += f"{item[0]} {(item[1].split('.')[1].title() + ' ' + item[1].split('.')[0].title()).upper():<20} {display_price:>10} 🍬\n"
+            else:
+                embed.description += f"{item[0]} {(item[1].split('.')[1].title() + ' ' + item[1].split('.')[0].title()).upper():<20} {item[2]:>3} 🍬\n"
         embed.description += "```"
         
         embed.set_thumbnail(url=self.author.display_avatar.url)


### PR DESCRIPTION
## PR Summary: Fix Collection Slot Updates Not Persisting and Rendering

This PR fixes an issue where users could run `qsetcollection` successfully but see no visible update in `qshowcollection`.

## Root Cause

The in-memory user cache merge logic did not correctly handle dotted update paths containing list indices (example: collections.iu.0).

When qsetcollection updated a slot, the cached collection structure could be reshaped incorrectly (list-like data treated as dict-like), so later reads and rendering in qshowcollection appeared unchanged.

## What Changed

1. Fixed dotted-path in-memory merge to support list indices safely  
- Updated traversal and write behavior in update_user.
- Added index-aware handling for set, unset, inc, and pathing behavior for push and pull flows.

2. Added collection shape normalization on user load  
- Added a normalization helper to repair corrupted collection shapes in cache (numeric-key dicts converted back into 6-slot lists).
- This makes the fix resilient for users already affected before deployment.

3. Fixed collection modal edge case  
- Initialized card before conditional lookup to avoid undefined-variable behavior when clearing a slot.
- Stored and reused resolved card id consistently for local view state and logs.


This branch has commits from `chii/fixes`. Probably better to merge that first